### PR TITLE
Feature/schedules card

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-intersection-observer": "^9.14.1",
+    "tailwindcss-animated": "^1.1.2",
     "zustand": "^5.0.2"
   },
   "devDependencies": {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,20 +1,5 @@
-import ScheduleCard from '@components/common/ScheduleCard';
-const dummyData = {
-  id: '550e8400-e29b-41d4-a716-446655440000', // uuid 형식
-  name: '3번째 모각코🔥', // text 형식
-  memo: '각자 모여서 공부하고 피드백 하기!각자 모여서 공부하고 피드백 하기!!각자 모여서 공부하고 피드백 하기!!각자 모여서 공부하고 피드백 하기!', // text 형식
-  start_date: '2025-01-09', // date 형식 (YYYY-MM-DD)
-  end_date: '2025-01-09', // date 형식 (YYYY-MM-DD)
-  start_time: '19:28:00', // time 형식 (HH:MM:SS)
-  created_at: '2024-06-01T12:00:00Z', // timestamptz 형식 (ISO 8601 형식)
-  group_id: '550e8400-e29b-41d4-a716-446655440000'
-};
 const HomePage = () => {
-  return (
-    <div>
-      home<ScheduleCard {...dummyData} groupName="나의 프론트 아카데미아" hasArrow={false}></ScheduleCard>
-    </div>
-  );
+  return <div>home</div>;
 };
 
 export default HomePage;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,20 @@
+import ScheduleCard from '@components/common/ScheduleCard';
+const dummyData = {
+  id: '550e8400-e29b-41d4-a716-446655440000', // uuid 형식
+  name: '3번째 모각코🔥', // text 형식
+  memo: '각자 모여서 공부하고 피드백 하기!각자 모여서 공부하고 피드백 하기!!각자 모여서 공부하고 피드백 하기!!각자 모여서 공부하고 피드백 하기!', // text 형식
+  start_date: '2025-01-09', // date 형식 (YYYY-MM-DD)
+  end_date: '2025-01-09', // date 형식 (YYYY-MM-DD)
+  start_time: '19:28:00', // time 형식 (HH:MM:SS)
+  created_at: '2024-06-01T12:00:00Z', // timestamptz 형식 (ISO 8601 형식)
+  group_id: '550e8400-e29b-41d4-a716-446655440000'
+};
 const HomePage = () => {
-  return <div>home</div>;
+  return (
+    <div>
+      home<ScheduleCard {...dummyData} groupName="나의 프론트 아카데미아" hasArrow={false}></ScheduleCard>
+    </div>
+  );
 };
 
 export default HomePage;

--- a/src/components/common/PostScheduleCard.tsx
+++ b/src/components/common/PostScheduleCard.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useState } from 'react';
+import { DownArrow, UpArrow } from '@components/icons';
+import { Database } from '@ts/supabase';
+import { formatDate, formatTime } from '@utils/dateUtils';
+type ScheduleType = Database['public']['Tables']['schedules']['Row'];
+
+const PostScheduleCard = ({ name, memo, start_date, end_date, start_time }: ScheduleType) => {
+  const [showDetails, setShowDetails] = useState(false);
+  const labelClass = 'text-gray-500 whitespace-nowrap';
+  const detailClass = 'flex items-center gap-3';
+
+  const toggleDetails = () => {
+    setShowDetails((prev) => !prev);
+  };
+  const isSingleDay = end_date === start_date;
+  return (
+    <div className="box-border border border-gray-300 rounded-xl pl-[1.25rem] pr-[0.5rem] py-[0.5rem] gap-[0.5rem]">
+      <div className=" flex justify-between items-center">
+        <p className="text-lg font-semibold leading-[140%]">{name}</p>
+
+        <div onClick={toggleDetails} className="min-w-6">
+          {showDetails ? <UpArrow /> : <DownArrow />}
+        </div>
+      </div>
+      <div className={` ${showDetails ? 'block animate-fade-down animate-duration-200' : 'hidden'} mt-2`}>
+        <div className={detailClass}>
+          <span className={labelClass}>메모</span>
+          <span className="truncate w-full">{memo}</span>
+        </div>
+
+        <div className="flex items-center whitespace-nowrap">
+          <span className={`${labelClass} pr-[12px]`}>일자</span>
+          <span>{formatDate(start_date)}</span>
+          {isSingleDay ? (
+            ''
+          ) : (
+            <>
+              <span className="px-[4px]">⁓</span>
+              <span className="truncate">{formatDate(end_date)}</span>
+            </>
+          )}
+        </div>
+        <div className={detailClass}>
+          <span className={labelClass}>시간</span>
+          <span>{formatTime(start_time)}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PostScheduleCard;

--- a/src/components/common/ScheduleCard.tsx
+++ b/src/components/common/ScheduleCard.tsx
@@ -3,10 +3,12 @@ import { Database } from '@ts/supabase';
 import { formatDate, formatTime } from '@utils/dateUtils';
 
 type ScheduleType = Database['public']['Tables']['schedules']['Row'];
+
 interface ScheduleCardProps extends ScheduleType {
   groupName?: string;
   hasArrow?: boolean;
 }
+
 const ScheduleCard = ({
   name,
   memo,

--- a/src/components/common/ScheduleCard.tsx
+++ b/src/components/common/ScheduleCard.tsx
@@ -33,7 +33,7 @@ const ScheduleCard = ({
         <div className="pb-[4px] text-gray-600">{groupName}</div>
         <div className="flex flex-col"></div>
         <p className="text-lg font-semibold leading-[140%] mb-2">{name}</p>
-        <div className={`${detailClass}`}>
+        <div className={detailClass}>
           <span className={labelClass}>메모</span>
           <span className="truncate w-full">{memo}</span>
         </div>

--- a/src/components/common/ScheduleCard.tsx
+++ b/src/components/common/ScheduleCard.tsx
@@ -1,40 +1,59 @@
+import { NextArrow } from '@components/icons';
 import { Database } from '@ts/supabase';
 import { formatDate, formatTime } from '@utils/dateUtils';
 
 type ScheduleType = Database['public']['Tables']['schedules']['Row'];
-
-const ScheduleCard = ({ name, memo, start_date, end_date, start_time }: ScheduleType) => {
-  const labelClass = 'text-gray-400'; // 라벨 스타일
+interface ScheduleCardProps extends ScheduleType {
+  groupName?: string;
+  hasArrow?: boolean;
+}
+const ScheduleCard = ({
+  name,
+  memo,
+  start_date,
+  end_date,
+  start_time,
+  groupName,
+  hasArrow = true
+}: ScheduleCardProps) => {
+  const labelClass = 'text-gray-500 whitespace-nowrap'; // 라벨 스타일
   const detailClass = 'flex items-center gap-3';
+  const isExpired = new Date(end_date) < new Date();
+  const isSingleDay = end_date === start_date;
 
   return (
-    <div className="inner border border-gray-300 rounded-xl flex justify-between items-center p-4 gap-[8px]">
-      <div className="flex flex-col">
+    <div
+      className={`box-border border border-gray-300 rounded-xl flex justify-between items-center pl-[1.25rem] pr-[0.5rem] py-[0.5rem] gap-[0.5rem]  ${
+        isExpired ? 'bg-gray-100' : ''
+      }`}
+    >
+      <div className="flex flex-col w-full w-11/12">
+        <div className="pb-[4px] text-gray-600">{groupName}</div>
+        <div className="flex flex-col"></div>
         <p className="text-lg font-semibold leading-[140%] mb-2">{name}</p>
-        <div className={detailClass}>
+        <div className={`${detailClass}`}>
           <span className={labelClass}>메모</span>
-          <span>{memo}</span>
+          <span className="truncate w-full">{memo}</span>
         </div>
-        <div className="flex items-center">
+        <div className="flex items-center whitespace-nowrap">
           <span className={`${labelClass} pr-[12px]`}>일자</span>
           <span>{formatDate(start_date)}</span>
-          <span className="px-[4px]">⁓</span>
-          <span>{formatDate(end_date)}</span>
+          {isSingleDay ? (
+            ''
+          ) : (
+            <>
+              <span className="px-[4px]">⁓</span>
+              <span className="truncate">{formatDate(end_date)}</span>
+            </>
+          )}
         </div>
         <div className={detailClass}>
           <span className={labelClass}>시간</span>
           <span>{formatTime(start_time)}</span>
         </div>
       </div>
-      {/* svg */}
-      <svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path
-          d="M10 18.5L15.2929 13.2071C15.6834 12.8166 15.6834 12.1834 15.2929 11.7929L10 6.5"
-          stroke="#A1A1AA"
-          strokeWidth="2"
-          strokeLinecap="round"
-        />
-      </svg>
+
+      {hasArrow ? <NextArrow className="min-w-6" /> : null}
     </div>
   );
 };

--- a/src/components/common/SmallAlert.tsx
+++ b/src/components/common/SmallAlert.tsx
@@ -1,8 +1,6 @@
-'use client';
-
 type SmallAlertProps = {
-  children: React.ReactNode;
-  show: boolean;
+  children: React.ReactNode; //알럿 내용용
+  show: boolean; //열림/닫힘 상태값
 };
 
 const SmallAlert = ({ children, show }: SmallAlertProps) => {

--- a/src/components/common/SmallAlert.tsx
+++ b/src/components/common/SmallAlert.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+type SmallAlertProps = {
+  children: React.ReactNode;
+  show: boolean;
+};
+
+const SmallAlert = ({ children, show }: SmallAlertProps) => {
+  if (!show) return null;
+  return (
+    <div className="w-full flex justify-center items-center fixed bottom-[6rem]">
+      <div className="animate-fade-up animate-once animate-duration-450 bg-black text-white py-2 px-4 rounded-[0.75rem]">
+        <div className="flex items-center gap-1">{children}</div>
+      </div>
+    </div>
+  );
+};
+
+export default SmallAlert;

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -113,6 +113,25 @@ export const DownArrow = ({ className }: IconProps) => {
     </svg>
   );
 };
+export const UpArrow = ({ className }: IconProps) => {
+  return (
+    <svg
+      className={className}
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M18 14L12.7071 8.70711C12.3166 8.31658 11.6834 8.31658 11.2929 8.70711L6 14"
+        stroke="#A1A1AA"
+        stroke-width="2"
+        stroke-linecap="round"
+      />
+    </svg>
+  );
+};
 
 export const Modification = ({ className }: IconProps) => {
   return (

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,6 +11,7 @@ const config: Config = {
     extend: {
       colors: {
         primary: '#B94600',
+        'gray-100': '#F4F4F5',
         'gray-300': '#D4D4D8',
         'gray-400': '#A1A1AA',
         'gray-500': '#71717A',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from 'tailwindcss';
+import tailwindcssAnimated from 'tailwindcss-animated';
 
 const config: Config = {
   content: [
@@ -21,6 +22,6 @@ const config: Config = {
       group_card: '0px -2px 4px 0px rgba(0, 0, 0, 0.05), 0px 4px 8px 0px rgba(0, 0, 0, 0.10)'
     }
   },
-  plugins: []
+  plugins: [tailwindcssAnimated]
 };
 export default config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2685,6 +2685,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+tailwindcss-animated@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/tailwindcss-animated/-/tailwindcss-animated-1.1.2.tgz#cc8aabe5b371abdf20a195809785b3dbf34adcd5"
+  integrity sha512-SI4owS5ojserhgEYIZA/uFVdNjU2GMB2P3sjtjmFA52VxoUi+Hht6oR5+RdT+CxrX9cNNYEa+vbTWHvN9zbj3w==
+
 tailwindcss@^3.4.17:
   version "3.4.17"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.4.17.tgz#ae8406c0f96696a631c790768ff319d46d5e5a63"


### PR DESCRIPTION
## Title

- SmallAlert 컴포넌트 생성, SchedulCard 컴포넌트 수정, 게시글용 일정 카드 컴포넌트 생성

## Changes

- SmallAlert 컴포넌트 완성화면
![image](https://github.com/user-attachments/assets/bb7da29c-e6c6-4301-93b1-b42671155c40)

- 사용하실 컴포넌트에 알럿 여닫는 상태 전달해주셔야 합니다. 
- 사용예시
```
import SmallAlert from '@components/common/SmallAlert';
import { useState } from 'react';

const App = () => {
  const [showAlert, setShowAlert] = useState(false);

  const handleButtonClick = () => {
    setShowAlert(true);
    setTimeout(() => setShowAlert(false), 2500); //2500이면 적당하더라고요...
  };

  return (
    <div className="p-4">
      <button onClick={handleButtonClick} className="bg-blue-500 text-white px-4 py-2 rounded">
        Show Alert
      </button>

      <SmallAlert show={showAlert}>수정 완료!</SmallAlert>
    </div>
  );
};

export default App;
```

-  tailwindcss-animated 설치 - 컴포넌트 애니메이션 적용을 위해 설치했습니다. 같이 활용해주시면 좋을 것 같아요
[tailwindcss-animated 사용법](https://www.tailwindcss-animated.com/configurator.html?animation=fade-up&count=once&duration=1000&delay=2000l)

- SchedulCard 를 수정했습니다
- groupName과 hasArrow를 props로 추가하여 커스텀하여 사용 가능
- 지난 일정은 bg-gray 처리
- 넘치는 텍스트 '...' 처리
![image](https://github.com/user-attachments/assets/0d17ff8b-c5ef-4baa-b4f7-552a8afe72ba)



- 게시글용 SchedulCard를 생성했습니다.
![loldex7](https://github.com/user-attachments/assets/481749e6-8dc0-453e-a7ff-f88fb86adb57)

-게시글용 SchedulCard 에 들어갈 아이콘을 icons/index 파일에 하나 추가해두었습니다.

## PR 생성 날짜

- 2024.01.09

## CheckList

- pull 받으신 후 yarn 한번 해주세요