### PR TITLE
feat: 바텀 네비게이션 경로에 따라 조건부 랜더링

### DIFF
--- a/src/components/common/BottomNav.tsx
+++ b/src/components/common/BottomNav.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import useNavStore from 'stores/useNavStore';
+import { usePathname } from 'next/navigation';
 import { Home, Chat, User } from '@components/icons';
 
 const buttons = [
@@ -30,8 +31,15 @@ const buttons = [
 
 const BottomNav = () => {
   const { activeButton, setActiveButton } = useNavStore();
+  const pathname = usePathname();
 
-  //console.log('activeButton', activeButton);
+  // 특정 경로에서 BottomNav를 숨김
+  const hiddenPaths = ['/login', '/signup', '/new'];
+  const isHideNav = hiddenPaths.some((path) => pathname.includes(path));
+
+  if (isHideNav) {
+    return null; // 조건 만족 시 BottomNav를 렌더링하지 않음
+  }
 
   return (
     <div className="fixed bottom-0 left-0 w-full h-16 bg-white flex shadow-[0px_-4px_4px_0px_rgba(0,0,0,0.1)] z-30">


### PR DESCRIPTION
## Title

- 바텀 네비게이션 경로에 따라 조건부 렌더링

## Changes

- (임시)BottomNav가 작업하실 때 화면을 가려 방해할 수 있을 것 같아, 경로에 login, signup, new가 있는 경우 보이지 않도록 처리했습니다. 추후 코드 수정이나 조건 추가가 필요할 것 같습니다.

## PR 생성 날짜

- 2024.01.10

## CheckList

- 
