### PR TITLE
fix: padding-bottom 수정하여 모임카드가 bottom nav에 가리던 문제 해결

### DIFF
--- a/src/app/_components/HomeContents.tsx
+++ b/src/app/_components/HomeContents.tsx
@@ -4,7 +4,7 @@ import NoGroup from './NoGroup';
 
 const HomeContents = () => {
   const isGroup = true;
-  const GroupListBoxStyle = `h-auto pb-5 bg-white rounded-t-[1.25rem]`;
+  const GroupListBoxStyle = `h-auto pb-[5.25rem] bg-white rounded-t-[1.25rem]`;
   return (
     <>
       <div className="px-5 pt-[5.625rem] pb-[2.313rem]">


### PR DESCRIPTION
## Title

-padding-bottom 수정하여 모임카드가 bottom nav에 가리던 문제 해결

## Changes

-padding-bottom 수정했습니다! 변경사항은 그뿐입니다.

## PR 생성 날짜

- 2025.01.10

## CheckList

-X
