### PR TITLE
feat: 멤버 관리페이지, 멤버 목록 페이지 토스트 +새로운 아이콘 두개

### DIFF
--- a/src/app/groups/[id]/management/_components/ManagementContents.tsx
+++ b/src/app/groups/[id]/management/_components/ManagementContents.tsx
@@ -65,9 +65,8 @@ const ManagementContents = ({ id }: ManagementContentsProps) => {
       <ManagementModal isLeader={isLeader} modalMode={modalMode} />
       <LinkCopiedAlert>
         <div className="flex gap-2.5">
-          {' '}
-          <CircleOk /> <span>{'초대링크가 복사 되었어요!'}</span>{' '}
-        </div>{' '}
+          <CircleOk /> <span>{'초대링크가 복사 되었어요!'}</span>
+        </div>
       </LinkCopiedAlert>
     </>
   );

--- a/src/app/groups/[id]/management/_components/ManagementContents.tsx
+++ b/src/app/groups/[id]/management/_components/ManagementContents.tsx
@@ -7,7 +7,8 @@ import ManagementCard from './ManagementCard';
 import ToggleBox from './ToggleBox';
 import ManagementBtns from './ManagementBtns';
 import ManagementModal from './modal/ManagementModal';
-import { Copy, NextArrow } from '@components/icons';
+import { CircleOk, Copy, NextArrow } from '@components/icons';
+import useSmallAlert from '@hooks/useSmallAlert';
 
 export type ModalModeType = 'changeProfile' | 'deleteGroup' | 'leaveGroup' | 'leaderTransition';
 interface ManagementContentsProps {
@@ -18,10 +19,13 @@ const ManagementContents = ({ id }: ManagementContentsProps) => {
   //1113b74a-2ec2-4f35-b044-4f42925cc076 얼그레이 연구회 아이디
   const [modalMode, setModalMode] = useState<ModalModeType | null>(null);
   const { openModal } = useModalStore();
+  const { SmallAlert: LinkCopiedAlert, openAlert: OpenLinkCopiedAlert } = useSmallAlert();
+
   const handleOpenModal = async (mode: ModalModeType) => {
     setModalMode(mode);
     openModal();
   };
+
   const isLeader = true;
 
   return (
@@ -48,7 +52,7 @@ const ManagementContents = ({ id }: ManagementContentsProps) => {
           </ManagementSection>
 
           <ManagementSection title={'멤버 관리'} isLast={true}>
-            <ManagementCard label={'멤버 초대링크 복사하기'}>
+            <ManagementCard label={'멤버 초대링크 복사하기'} handleClick={OpenLinkCopiedAlert}>
               <Copy />
             </ManagementCard>
             <ManagementCard label={'멤버 목록'} link={`/groups/${id}/management/members`}>
@@ -59,6 +63,12 @@ const ManagementContents = ({ id }: ManagementContentsProps) => {
         <ManagementBtns isLeader={isLeader} handleOpenModal={handleOpenModal} />
       </div>
       <ManagementModal isLeader={isLeader} modalMode={modalMode} />
+      <LinkCopiedAlert>
+        <div className="flex gap-2.5">
+          {' '}
+          <CircleOk /> <span>{'초대링크가 복사 되었어요!'}</span>{' '}
+        </div>{' '}
+      </LinkCopiedAlert>
     </>
   );
 };

--- a/src/app/groups/[id]/management/members/_components/MemberCard.tsx
+++ b/src/app/groups/[id]/management/members/_components/MemberCard.tsx
@@ -4,12 +4,13 @@ import Image from 'next/image';
 import MemberCardLeaderBtns from './MemberCardLeaderBtns';
 
 interface MemberCardProps {
+  toastOpener?: () => void;
   isLeaderUser: boolean;
   isLeader?: boolean;
   isMe?: boolean;
   mode: 'curMembers' | 'waiting';
 }
-const MemberCard = ({ isLeaderUser, isLeader = false, isMe = false, mode }: MemberCardProps) => {
+const MemberCard = ({ toastOpener, isLeaderUser, isLeader = false, isMe = false, mode }: MemberCardProps) => {
   const profile =
     'https://sozcwgcoibigujehjxbf.supabase.co/storage/v1/object/public/profiles/users/ebcc66fe-bf21-4b73-99d1-e4f375025b80/winterhotchocolate.jpg';
   const name = '이름이에요';
@@ -26,7 +27,7 @@ const MemberCard = ({ isLeaderUser, isLeader = false, isMe = false, mode }: Memb
           </span>
         </div>
         {isLeaderUser ? (
-          <MemberCardLeaderBtns isLeader={isLeader} mode={mode} />
+          <MemberCardLeaderBtns isLeader={isLeader} mode={mode} toastOpener={toastOpener ? toastOpener : null} />
         ) : (
           <>{mode === 'curMembers' && isLeader && <span className="text-primary">대표</span>}</>
         )}

--- a/src/app/groups/[id]/management/members/_components/MemberCardLeaderBtns.tsx
+++ b/src/app/groups/[id]/management/members/_components/MemberCardLeaderBtns.tsx
@@ -3,16 +3,22 @@
 import ManageMembersBtn from './ManageMembersBtn';
 
 interface MemberCardBtnsProps {
+  toastOpener: (() => void) | null;
   isLeader: boolean;
   mode: 'curMembers' | 'waiting';
 }
-const MemberCardLeaderBtns = ({ isLeader, mode }: MemberCardBtnsProps) => {
+const MemberCardLeaderBtns = ({ isLeader, mode, toastOpener }: MemberCardBtnsProps) => {
+  const onPermit = () => {
+    if (toastOpener) toastOpener();
+  };
   return (
     <>
       {mode === 'curMembers' && (isLeader ? <span className="text-primary">대표</span> : <ManageMembersBtn />)}
       {mode === 'waiting' && (
         <div>
-          <button type="button">수락</button>
+          <button type="button" onClick={onPermit}>
+            수락
+          </button>
           <button type="button" className="ml-4 px-2.5 py-[0.438rem] bg-[#3B82F6] rounded-lg text-white font-semibold">
             거절
           </button>

--- a/src/app/groups/[id]/management/members/_components/WaitingMemberList.tsx
+++ b/src/app/groups/[id]/management/members/_components/WaitingMemberList.tsx
@@ -1,24 +1,34 @@
 'use client';
 
 import MemberCard from './MemberCard';
-
+import useSmallAlert from '@hooks/useSmallAlert';
+import { AddMember } from '@components/icons';
 interface WaitingMemberListProps {
   isLeaderUser: boolean;
 }
 const WaitingMemberList = ({ isLeaderUser }: WaitingMemberListProps) => {
+  const { SmallAlert: MemberAddedAlert, openAlert: OpenMemberAddedAlert } = useSmallAlert();
   return (
-    <div>
-      <div className="pt-5 font-semibold">
-        <div className="px-5 py-3 flex items-center gap-2">
-          <span>대기 멤버</span> <span className="text-primary">3</span>
+    <>
+      <div>
+        <div className="pt-5 font-semibold">
+          <div className="px-5 py-3 flex items-center gap-2">
+            <span>대기 멤버</span> <span className="text-primary">3</span>
+          </div>
+        </div>
+        <div>
+          <MemberCard isLeaderUser={isLeaderUser} mode={'waiting'} toastOpener={OpenMemberAddedAlert} />
+          <MemberCard isLeaderUser={isLeaderUser} mode={'waiting'} toastOpener={OpenMemberAddedAlert} />
+          <MemberCard isLeaderUser={isLeaderUser} mode={'waiting'} toastOpener={OpenMemberAddedAlert} />
         </div>
       </div>
-      <div>
-        <MemberCard isLeaderUser={isLeaderUser} mode={'waiting'} />
-        <MemberCard isLeaderUser={isLeaderUser} mode={'waiting'} />
-        <MemberCard isLeaderUser={isLeaderUser} mode={'waiting'} />
-      </div>
-    </div>
+      <MemberAddedAlert>
+        <div className="flex gap-2.5">
+          <AddMember />
+          <span>{'멤버가 추가 되었어요!'}</span>
+        </div>
+      </MemberAddedAlert>
+    </>
   );
 };
 

--- a/src/app/groups/[id]/management/members/_components/WaitingMemberList.tsx
+++ b/src/app/groups/[id]/management/members/_components/WaitingMemberList.tsx
@@ -1,13 +1,15 @@
 'use client';
 
 import MemberCard from './MemberCard';
-import useSmallAlert from '@hooks/useSmallAlert';
 import { AddMember } from '@components/icons';
+import useSmallAlert from '@hooks/useSmallAlert';
+
 interface WaitingMemberListProps {
   isLeaderUser: boolean;
 }
 const WaitingMemberList = ({ isLeaderUser }: WaitingMemberListProps) => {
   const { SmallAlert: MemberAddedAlert, openAlert: OpenMemberAddedAlert } = useSmallAlert();
+
   return (
     <>
       <div>

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -656,3 +656,50 @@ export const Leader = ({ className }: IconProps) => {
     </svg>
   );
 };
+
+export const AddMember = ({ className }: IconProps) => {
+  return (
+    <svg
+      className={className}
+      width="24"
+      height="25"
+      viewBox="0 0 24 25"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M9.5 10.5C9.95963 10.5 10.4148 10.4095 10.8394 10.2336C11.264 10.0577 11.6499 9.79988 11.9749 9.47487C12.2999 9.14987 12.5577 8.76403 12.7336 8.33939C12.9095 7.91475 13 7.45963 13 7C13 6.54037 12.9095 6.08525 12.7336 5.66061C12.5577 5.23597 12.2999 4.85013 11.9749 4.52513C11.6499 4.20012 11.264 3.94231 10.8394 3.76642C10.4148 3.59053 9.95963 3.5 9.5 3.5C8.57174 3.5 7.6815 3.86875 7.02513 4.52513C6.36875 5.1815 6 6.07174 6 7C6 7.92826 6.36875 8.8185 7.02513 9.47487C7.6815 10.1313 8.57174 10.5 9.5 10.5Z"
+        stroke="white"
+        stroke-width="1.5"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M18 15V21M15 18H21M13.5 14.5H9.4C7.16 14.5 6.04 14.5 5.184 14.936C4.43139 15.3195 3.81949 15.9314 3.436 16.684C3 17.54 3 18.66 3 20.9V21.5H13.5"
+        stroke="white"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  );
+};
+
+export const CircleOk = ({ className }: IconProps) => {
+  return (
+    <svg
+      className={className}
+      width="24"
+      height="25"
+      viewBox="0 0 24 25"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M7 13.5L9.64645 16.1464C9.84171 16.3417 10.1583 16.3417 10.3536 16.1464L17 9.5M12 22.5C17.5228 22.5 22 18.0228 22 12.5C22 6.97715 17.5228 2.5 12 2.5C6.47715 2.5 2 6.97715 2 12.5C2 18.0228 6.47715 22.5 12 22.5Z"
+        stroke="white"
+        stroke-width="1.5"
+        stroke-linecap="round"
+      />
+    </svg>
+  );
+};


### PR DESCRIPTION
## Title

-멤버 관리페이지, 멤버 목록 페이지 토스트 +새로운 아이콘 두개

## Changes

-멤버 관리페이지, 멤버 목록 페이지에 토스트 얼러트를 추가했습니다.
-새로운 아이콘 두개를 추가했습니다. (AddMember, CircleOk)

<img src='https://github.com/user-attachments/assets/1917395c-eeba-4e0c-857c-259fbab044a1'>

<img src='https://github.com/user-attachments/assets/f68fa518-1345-422c-af33-3e9e99a6d6a8'>


## PR 생성 날짜

- 2025.01.14

## CheckList

- [x] 불필요한 주석이 남아 있지는 않은가요?
- [x] 테스트 할 때 사용했던 console.log 가 남아있지 않은가요?
- [x] 코드 컨벤션이 잘 지켜져 있나요?
