### PR TITLE
feat: 멤버 목록 페이지에서 참여 멤버 보여주기

### DIFF
--- a/src/app/_components/GroupList.tsx
+++ b/src/app/_components/GroupList.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import GroupCard from '@components/common/groupCard/GroupCard';
-import { fetchGroupCardInfos } from '@utils/actions/home/fetchGroupList';
+import { fetchGroupCardInfos } from 'queries/home/fetchGroupInfo';
 import { GroupCardInfosType } from '@components/common/groupCard/GroupCard';
 
 const GroupList = () => {

--- a/src/app/groups/[id]/management/_components/ManagementContents.tsx
+++ b/src/app/groups/[id]/management/_components/ManagementContents.tsx
@@ -9,12 +9,13 @@ import ManagementBtns from './ManagementBtns';
 import ManagementModal from './modal/ManagementModal';
 import { CircleOk, Copy, NextArrow } from '@components/icons';
 import useSmallAlert from '@hooks/useSmallAlert';
+import useIsLeader from '@hooks/management/useIsLeader';
 
 export type ModalModeType = 'changeProfile' | 'deleteGroup' | 'leaveGroup' | 'leaderTransition';
 interface ManagementContentsProps {
-  id: string;
+  groupId: string;
 }
-const ManagementContents = ({ id }: ManagementContentsProps) => {
+const ManagementContents = ({ groupId }: ManagementContentsProps) => {
   //52f44a96-b8f7-4c6c-80b1-d657eafd3821 모닥모닥팀 아이디
   //1113b74a-2ec2-4f35-b044-4f42925cc076 얼그레이 연구회 아이디
   const [modalMode, setModalMode] = useState<ModalModeType | null>(null);
@@ -26,7 +27,9 @@ const ManagementContents = ({ id }: ManagementContentsProps) => {
     openModal();
   };
 
-  const isLeader = true;
+  const { data: isLeader, isPending, isError } = useIsLeader({ groupId });
+  if (isPending) return <div>Loading...</div>;
+  if (isError) return <div>Error!</div>;
 
   return (
     <>
@@ -55,14 +58,14 @@ const ManagementContents = ({ id }: ManagementContentsProps) => {
             <ManagementCard label={'멤버 초대링크 복사하기'} handleClick={OpenLinkCopiedAlert}>
               <Copy />
             </ManagementCard>
-            <ManagementCard label={'멤버 목록'} link={`/groups/${id}/management/members`}>
+            <ManagementCard label={'멤버 목록'} link={`/groups/${groupId}/management/members`}>
               <NextArrow />
             </ManagementCard>
           </ManagementSection>
         </div>
-        <ManagementBtns isLeader={isLeader} handleOpenModal={handleOpenModal} />
+        <ManagementBtns isLeader={isLeader ? isLeader : false} handleOpenModal={handleOpenModal} />
       </div>
-      <ManagementModal isLeader={isLeader} modalMode={modalMode} />
+      <ManagementModal isLeader={isLeader ? isLeader : false} modalMode={modalMode} />
       <LinkCopiedAlert>
         <div className="flex gap-2.5">
           <CircleOk /> <span>{'초대링크가 복사 되었어요!'}</span>

--- a/src/app/groups/[id]/management/_components/modal/leaveGroup/LeavingSuccess.tsx
+++ b/src/app/groups/[id]/management/_components/modal/leaveGroup/LeavingSuccess.tsx
@@ -7,7 +7,7 @@ const LeavingSuccess = () => {
   return (
     <>
       <div className="w-full py-6 text-left">
-        <h4 className="mb-1 text-lg font-semibold text-gray-900">모임이 삭제되었어요</h4>
+        <h4 className="mb-1 text-lg font-semibold text-gray-900">모임을 탈퇴했어요</h4>
         <div className="text-gray-500">다시 뵐 수 있으면 좋겠어요!</div>
       </div>
       <Link href="/" className="w-full mt-5">

--- a/src/app/groups/[id]/management/members/_components/CurMemberList.tsx
+++ b/src/app/groups/[id]/management/members/_components/CurMemberList.tsx
@@ -1,26 +1,67 @@
 'use client';
 
+import { usePathname } from 'next/navigation';
 import MemberCard from './MemberCard';
+import useFetchCurMembers from '@hooks/management/useFetchCurMembers';
+
+const DEFAULTDATA = {
+  group_id: '',
+  is_approved: true,
+  is_leader: false,
+  users: { id: '', nickname: '', profile_image: '' },
+};
 
 interface CurMemberListProps {
   isLeaderUser: boolean;
 }
 const CurMemberList = ({ isLeaderUser }: CurMemberListProps) => {
-  //나의 멤버카드가 리스트의 최상단에 오나?
+  const path = usePathname();
+  const groupId = path.split('/').filter((c) => c !== '')[1];
+
+  const { data: curMemberList, isPending, isError } = useFetchCurMembers({ groupId });
+  if (isPending) return <div>Loading...</div>;
+  if (isError) return <div>Error!</div>;
+
+  //유저가 리더가 아닐 때 멤버 데이터에서 리더 데이터를 뽑아내기
+  const filteredLeaderData =
+    isLeaderUser || !curMemberList ? null : curMemberList.others.find((member) => member.is_leader === true);
+  const leaderData = filteredLeaderData ? filteredLeaderData : DEFAULTDATA;
+  
+  //리더를 제외한 멤버들의 데이터
+  const filteredData = !curMemberList ? null : curMemberList.others.filter((member) => member.is_leader !== true);
+
   return (
     <div>
       <div className="pt-5 font-semibold">
         <div className="px-5 py-3 flex items-center gap-2">
-          <span>현재 참여 멤버</span> <span className="text-primary">6</span>
+          <span>현재 참여 멤버</span>
+          <span className="text-primary">{curMemberList ? curMemberList.others.length + 1 : '...'}</span>
         </div>
       </div>
       <div>
-        <MemberCard isLeaderUser={isLeaderUser} mode={'curMembers'} isMe={true} />
-        <MemberCard isLeaderUser={isLeaderUser} isLeader={true} mode={'curMembers'} />
-        <MemberCard isLeaderUser={isLeaderUser} mode={'curMembers'} />
-        <MemberCard isLeaderUser={isLeaderUser} mode={'curMembers'} />
-        <MemberCard isLeaderUser={isLeaderUser} mode={'curMembers'} />
-        <MemberCard isLeaderUser={isLeaderUser} mode={'curMembers'} />
+        {curMemberList && (
+          <>
+            {isLeaderUser ? (
+              <>
+                <MemberCard
+                  memberData={curMemberList.me}
+                  isLeaderUser={isLeaderUser}
+                  mode={'curMembers'}
+                  isLeader={true}
+                  isMe={true}
+                />
+              </>
+            ) : (
+              <>
+                <MemberCard memberData={curMemberList.me} isLeaderUser={isLeaderUser} mode={'curMembers'} isMe={true} />
+                <MemberCard memberData={leaderData} isLeaderUser={isLeaderUser} mode={'curMembers'} isLeader={true} />
+              </>
+            )}
+            {filteredData?.map((member) => (
+              <MemberCard key={member.users.id} memberData={member} isLeaderUser={isLeaderUser} mode={'curMembers'} />
+            ))}
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/app/groups/[id]/management/members/_components/CurMemberList.tsx
+++ b/src/app/groups/[id]/management/members/_components/CurMemberList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { usePathname } from 'next/navigation';
+import { useParams } from 'next/navigation';
 import MemberCard from './MemberCard';
 import useFetchCurMembers from '@hooks/management/useFetchCurMembers';
 
@@ -15,8 +15,8 @@ interface CurMemberListProps {
   isLeaderUser: boolean;
 }
 const CurMemberList = ({ isLeaderUser }: CurMemberListProps) => {
-  const path = usePathname();
-  const groupId = path.split('/').filter((c) => c !== '')[1];
+  const { id } = useParams();
+  const groupId = Array.isArray(id) ? id[0] : id;
 
   const { data: curMemberList, isPending, isError } = useFetchCurMembers({ groupId });
   if (isPending) return <div>Loading...</div>;
@@ -26,7 +26,7 @@ const CurMemberList = ({ isLeaderUser }: CurMemberListProps) => {
   const filteredLeaderData =
     isLeaderUser || !curMemberList ? null : curMemberList.others.find((member) => member.is_leader === true);
   const leaderData = filteredLeaderData ? filteredLeaderData : DEFAULTDATA;
-  
+
   //리더를 제외한 멤버들의 데이터
   const filteredData = !curMemberList ? null : curMemberList.others.filter((member) => member.is_leader !== true);
 

--- a/src/app/groups/[id]/management/members/_components/MemberCard.tsx
+++ b/src/app/groups/[id]/management/members/_components/MemberCard.tsx
@@ -2,18 +2,26 @@
 
 import Image from 'next/image';
 import MemberCardLeaderBtns from './MemberCardLeaderBtns';
+import { CurMemberType } from 'queries/management/fetchMembers';
 
 interface MemberCardProps {
+  memberData: CurMemberType;
   toastOpener?: () => void;
   isLeaderUser: boolean;
   isLeader?: boolean;
   isMe?: boolean;
   mode: 'curMembers' | 'waiting';
 }
-const MemberCard = ({ toastOpener, isLeaderUser, isLeader = false, isMe = false, mode }: MemberCardProps) => {
-  const profile =
-    'https://sozcwgcoibigujehjxbf.supabase.co/storage/v1/object/public/profiles/users/ebcc66fe-bf21-4b73-99d1-e4f375025b80/winterhotchocolate.jpg';
-  const name = '이름이에요';
+const MemberCard = ({
+  memberData,
+  toastOpener,
+  isLeaderUser,
+  isLeader = false,
+  isMe = false,
+  mode,
+}: MemberCardProps) => {
+  const {users} = memberData;
+  const { nickname, profile_image: profile } = users;
 
   return (
     <div className="w-full border-b border-gray-200">
@@ -23,7 +31,7 @@ const MemberCard = ({ toastOpener, isLeaderUser, isLeader = false, isMe = false,
             <Image src={profile} width={100} height={100} alt={'member_profile'} />
           </div>
           <span className="flex items-center gap-1">
-            {name} {isMe && <span className="text-gray-500 text-sm">{'(나)'}</span>}
+            {nickname} {isMe && <span className="text-gray-500 text-sm">{'(나)'}</span>}
           </span>
         </div>
         {isLeaderUser ? (

--- a/src/app/groups/[id]/management/members/_components/MembersPageContents.tsx
+++ b/src/app/groups/[id]/management/members/_components/MembersPageContents.tsx
@@ -1,14 +1,19 @@
 'use client';
 
 import { useState } from 'react';
+import { usePathname } from 'next/navigation';
 import CurMemberList from './CurMemberList';
 import WaitingMemberList from './WaitingMemberList';
 import MembersBottomSheet from './MembersBottomSheet';
 import ManagementModal from '../../_components/modal/ManagementModal';
+import useIsLeader from '@hooks/management/useIsLeader';
 
 type TabType = 'currentMembers' | 'awaitingMembers';
 
 const MembersPageContents = () => {
+  const path = usePathname();
+  const groupId = path.split('/').filter((segment) => segment !== '')[1];
+
   const [selectedTab, setSelectedTab] = useState<TabType>('currentMembers');
 
   const handleCurMemTabClick = () => {
@@ -19,7 +24,9 @@ const MembersPageContents = () => {
     setSelectedTab('awaitingMembers');
   };
 
-  const isLeaderUser = true;
+  const { data: isLeaderUser, isPending, isError } = useIsLeader({ groupId });
+  if (isPending) return <div>Loading...</div>;
+  if (isError) return <div>Error!</div>;
 
   return (
     <>
@@ -41,11 +48,11 @@ const MembersPageContents = () => {
       </div>
 
       {selectedTab === 'currentMembers' ? (
-        <CurMemberList isLeaderUser={isLeaderUser} />
+        <CurMemberList isLeaderUser={isLeaderUser ? isLeaderUser : false} />
       ) : (
-        <WaitingMemberList isLeaderUser={isLeaderUser} />
+        <WaitingMemberList isLeaderUser={isLeaderUser ? isLeaderUser : false} />
       )}
-      <ManagementModal isLeader={isLeaderUser} modalMode={'leaderTransition'} />
+      <ManagementModal isLeader={isLeaderUser ? isLeaderUser : false} modalMode={'leaderTransition'} />
       <MembersBottomSheet />
     </>
   );

--- a/src/app/groups/[id]/management/members/_components/WaitingMemberList.tsx
+++ b/src/app/groups/[id]/management/members/_components/WaitingMemberList.tsx
@@ -10,6 +10,7 @@ interface WaitingMemberListProps {
 const WaitingMemberList = ({ isLeaderUser }: WaitingMemberListProps) => {
   const { SmallAlert: MemberAddedAlert, /*openAlert: OpenMemberAddedAlert*/ } = useSmallAlert();
   console.log(isLeaderUser); //빌드시 미사용 변수 에러가 일어나는 것을 막기 위해서 넣은 줄입니다.
+  
 
   return (
     <>

--- a/src/app/groups/[id]/management/members/_components/WaitingMemberList.tsx
+++ b/src/app/groups/[id]/management/members/_components/WaitingMemberList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import MemberCard from './MemberCard';
+//import MemberCard from './MemberCard';
 import { AddMember } from '@components/icons';
 import useSmallAlert from '@hooks/useSmallAlert';
 
@@ -8,7 +8,8 @@ interface WaitingMemberListProps {
   isLeaderUser: boolean;
 }
 const WaitingMemberList = ({ isLeaderUser }: WaitingMemberListProps) => {
-  const { SmallAlert: MemberAddedAlert, openAlert: OpenMemberAddedAlert } = useSmallAlert();
+  const { SmallAlert: MemberAddedAlert, /*openAlert: OpenMemberAddedAlert*/ } = useSmallAlert();
+  console.log(isLeaderUser); //빌드시 미사용 변수 에러가 일어나는 것을 막기 위해서 넣은 줄입니다.
 
   return (
     <>
@@ -19,9 +20,9 @@ const WaitingMemberList = ({ isLeaderUser }: WaitingMemberListProps) => {
           </div>
         </div>
         <div>
+          {/* <MemberCard isLeaderUser={isLeaderUser} mode={'waiting'} toastOpener={OpenMemberAddedAlert} />
           <MemberCard isLeaderUser={isLeaderUser} mode={'waiting'} toastOpener={OpenMemberAddedAlert} />
-          <MemberCard isLeaderUser={isLeaderUser} mode={'waiting'} toastOpener={OpenMemberAddedAlert} />
-          <MemberCard isLeaderUser={isLeaderUser} mode={'waiting'} toastOpener={OpenMemberAddedAlert} />
+          <MemberCard isLeaderUser={isLeaderUser} mode={'waiting'} toastOpener={OpenMemberAddedAlert} /> */}
         </div>
       </div>
       <MemberAddedAlert>

--- a/src/app/groups/[id]/management/page.tsx
+++ b/src/app/groups/[id]/management/page.tsx
@@ -14,7 +14,7 @@ const ManagementPage = ({ params }: ManagementPageProps) => {
   return (
     <main>
       <Header home={false} label={'관리 페이지'} />
-      <ManagementContents id={id}/>
+      <ManagementContents groupId={id} />
     </main>
   );
 };

--- a/src/hooks/management/useFetchCurMembers.tsx
+++ b/src/hooks/management/useFetchCurMembers.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { GroupsType } from 'queries/home/fetchGroupInfo';
+import { CurMemberType, fetchCurMembers } from 'queries/management/fetchMembers';
+
+interface UseFetchCurMembersParams {
+  groupId: GroupsType['id'];
+}
+const useFetchCurMembers = ({ groupId }: UseFetchCurMembersParams) => {
+  //const userId = 'af747db7-11c9-4bbc-800b-9c02eb04a886' //임시 유저 아이디 : 멤버예요
+  const userId = '6f565124-cfc9-46ef-b5ed-220680b11db3'; //임시 유저 아이디 : 관리자예요
+
+  const { data, isPending, isError } = useQuery({
+    queryKey: [`fetchCurMembers-${groupId}-${userId}`],
+    queryFn: async () => {
+      const data = await fetchCurMembers({ groupId });
+      if (data) {
+        const me = data.find((member) => member.users.id === userId) as CurMemberType;
+        const others = data.filter((member) => member.users.id !== userId);
+        return {me, others}
+      }
+      return null;
+    },
+  });
+
+  return { data, isPending, isError };
+};
+
+export default useFetchCurMembers;

--- a/src/hooks/management/useIsLeader.tsx
+++ b/src/hooks/management/useIsLeader.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { GroupsType } from 'queries/home/fetchGroupInfo';
+import { fetchLeaderInfo } from 'queries/management/fetchMembers';
+
+interface UseIsLeaderParams {
+  groupId: GroupsType['id'];
+}
+const useIsLeader = ({ groupId }: UseIsLeaderParams) => {
+  //const userId = 'af747db7-11c9-4bbc-800b-9c02eb04a886' //임시 유저 아이디 : 멤버예요
+  const userId = '6f565124-cfc9-46ef-b5ed-220680b11db3'; //임시 유저 아이디 : 관리자예요
+
+  const { data, isPending, isError } = useQuery({
+    queryKey: [`isLeader-${groupId}-${userId}`],
+    queryFn: async () => {
+      const data = await fetchLeaderInfo({ groupId });
+
+      if (data && data.users.id === userId) {
+        return true;
+      }
+      return false;
+    },
+  });
+
+  return { data, isPending, isError };
+};
+
+export default useIsLeader;

--- a/src/queries/home/fetchGroupInfo.ts
+++ b/src/queries/home/fetchGroupInfo.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { GroupCardInfosType } from '@components/common/groupCard/GroupCard';
-import { createClient } from '../../supabase/server';
+import { createClient } from '../../utils/supabase/server';
 import { Database } from '@ts/supabase';
 
 export type GroupMembersType = Database['public']['Tables']['group_members']['Row'];
@@ -12,7 +12,7 @@ interface FetchEnteredGroupListParams {
   userId: UsersType['id'];
 }
 export const fetchEnteredGroupList = async ({
-  userId
+  userId,
 }: FetchEnteredGroupListParams): Promise<GroupMembersType[] | null> => {
   try {
     const supabase = await createClient();
@@ -57,7 +57,7 @@ interface FetchGroupCardInfosParams {
   userId: UsersType['id'];
 }
 export const fetchGroupCardInfos = async ({
-  userId
+  userId,
 }: FetchGroupCardInfosParams): Promise<GroupCardInfosType[] | null> => {
   try {
     const enteredGroupList = await fetchEnteredGroupList({ userId });

--- a/src/queries/home/fetchGroupInfo.ts
+++ b/src/queries/home/fetchGroupInfo.ts
@@ -1,8 +1,9 @@
 'use server';
 
 import { GroupCardInfosType } from '@components/common/groupCard/GroupCard';
-import { createClient } from '../../utils/supabase/server';
+import { createClient } from '@utils/supabase/server';
 import { Database } from '@ts/supabase';
+
 
 export type GroupMembersType = Database['public']['Tables']['group_members']['Row'];
 export type GroupsType = Database['public']['Tables']['groups']['Row'];

--- a/src/queries/management/fetchMembers.ts
+++ b/src/queries/management/fetchMembers.ts
@@ -1,0 +1,86 @@
+'use server';
+
+import { createClient } from '../../utils/supabase/server';
+import { Database } from '@ts/supabase';
+import { GroupsType } from '../home/fetchGroupInfo';
+
+export type GroupMembersType = Database['public']['Tables']['group_members']['Row'];
+
+export interface filteredUsers {
+  id: string;
+  nickname: string;
+  profile_image: string;
+}
+export interface CurMemberType {
+  group_id: string;
+  is_approved: boolean;
+  is_leader: boolean;
+  users: filteredUsers;
+}
+
+interface FetchMembersParams {
+  groupId: GroupsType['id'];
+}
+export const fetchCurMembers = async ({ groupId }: FetchMembersParams): Promise<CurMemberType[] | null> => {
+  try {
+    const supabase = await createClient();
+    const { data } = await supabase
+      .from('group_members')
+      .select(`group_id, is_approved, is_leader, users( id, nickname, profile_image)`)
+      .eq('group_id', groupId)
+      .eq('is_approved', true);
+
+    return data as CurMemberType[] | null;
+  } catch (error) {
+    throw new Error(`${error}`);
+  }
+};
+
+export const fetchWaitingMembers = async ({ groupId }: FetchMembersParams): Promise<CurMemberType[] | null> => {
+  try {
+    const supabase = await createClient();
+    const { data } = await supabase
+      .from('group_members')
+      .select(`group_id, is_approved, is_leader, users( id, nickname, profile_image)`)
+      .eq('group_id', groupId)
+      .eq('is_approved', true);
+
+    return data as CurMemberType[] | null;
+  } catch (error) {
+    throw new Error(`${error}`);
+  }
+};
+
+interface FetchLeaderInfoParams {
+  groupId: GroupsType['id'];
+}
+export const fetchLeaderInfo = async ({ groupId }: FetchLeaderInfoParams): Promise<CurMemberType | null> => {
+  try {
+    const supabase = await createClient();
+    const { data } = await supabase
+      .from('group_members')
+      .select(`group_id, is_approved, is_leader, users( id, nickname, profile_image)`)
+      .eq('group_id', groupId)
+      .eq('is_leader', true)
+      .single();
+
+    return data as CurMemberType | null;
+  } catch (error) {
+    throw new Error(`${error}`);
+  }
+};
+
+// interface FetchUserInfoParams {
+//   userId: UsersType['id'];
+//   groupId: GroupsType['id'];
+// }
+// export const fetchUserInfo = async ({ userId, groupId }: FetchUserInfoParams): Promise<GroupMembersType | null> => {
+//   try {
+//     const supabase = await createClient();
+//     const { data } = await supabase.from('group_members').select().eq('group_id', groupId).eq('id', userId).single();
+
+//     return data;
+//   } catch (error) {
+//     throw new Error(`${error}`);
+//   }
+// };

--- a/src/queries/management/fetchMembers.ts
+++ b/src/queries/management/fetchMembers.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { createClient } from '../../utils/supabase/server';
+import { createClient } from '@utils/supabase/server';
 import { GroupsType } from '../home/fetchGroupInfo';
 import { Database } from '@ts/supabase';
 
@@ -43,7 +43,7 @@ export const fetchWaitingMembers = async ({ groupId }: FetchMembersParams): Prom
       .from('group_members')
       .select(`group_id, is_approved, is_leader, users( id, nickname, profile_image)`)
       .eq('group_id', groupId)
-      .eq('is_approved', true);
+      .eq('is_approved', false);
 
     return data as CurMemberType[] | null;
   } catch (error) {

--- a/src/queries/management/fetchMembers.ts
+++ b/src/queries/management/fetchMembers.ts
@@ -1,8 +1,8 @@
 'use server';
 
 import { createClient } from '../../utils/supabase/server';
-import { Database } from '@ts/supabase';
 import { GroupsType } from '../home/fetchGroupInfo';
+import { Database } from '@ts/supabase';
 
 export type GroupMembersType = Database['public']['Tables']['group_members']['Row'];
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,8 @@
       "@ts/*": ["types/*"],
       "@hooks/*": ["hooks/*"],
       "@stores/*": ["stores/*"],
-      "@lib/*": ["lib/*"]
+      "@lib/*": ["lib/*"],
+      "@queries/*": ["queries/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "src"],


### PR DESCRIPTION
## Title

-feat: 멤버 목록 페이지에서 참여 멤버 보여주기

## Changes

-멤버 목록 페이지에서 참여 멤버를 보여줄 수 있습니다.
-유저 더미데이터의 위치는 useFetchCurMembers.tsx와 useIsLeader.tsx입니다.
-서버액션 파일의 위치를 수정했습니다

주의
빌드 시 변수 미사용 에러가 일어나는 것을 막기 위해 
아직 작업하지 않은 WaitingMemberList컴포넌트의 props를 console.log()에 넣어두었습니다.
작업을 마친 뒤 삭제할 예정입니다!

## PR 생성 날짜

- 2025.01.15

## CheckList

- [x] 불필요한 주석이 남아 있지는 않은가요?
- [x] 테스트 할 때 사용했던 console.log 가 남아있지 않은가요?
- [ ] 코드 컨벤션이 잘 지켜져 있나요?
