### PR TITLE
feat: Header 컴포넌트 셋팅 버튼 클릭시 페이지 이동 적용 및 댓글 스타일 수정

### DIFF
--- a/src/app/_components/HomeSection.tsx
+++ b/src/app/_components/HomeSection.tsx
@@ -7,7 +7,6 @@ import Button from '@components/common/Button';
 import Header from '@components/common/Header';
 import { Plus } from '@components/icons';
 
-
 const HomeSection = () => {
   const router = useRouter();
   const [isScrolled, setIsScrolled] = useState<boolean>(false);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -46,18 +46,18 @@
     display: inline-block;
     width: 51px;
     height: 31px;
-}
-.toggle-btn .slider {
+  }
+  .toggle-btn .slider {
     position: absolute;
     cursor: pointer;
     inset: 0px;
-    background-color: #F1F1F1;
+    background-color: #f1f1f1;
     transition: all 0.2s ease 0s;
     border-radius: 34px;
-}
-.toggle-btn .slider::before {
+  }
+  .toggle-btn .slider::before {
     position: absolute;
-    content: "";
+    content: '';
     width: 25px;
     height: 25px;
     left: 2px;
@@ -66,13 +66,28 @@
     transition: all 0.2s ease 0s;
     border-radius: 50%;
     box-shadow: rgba(0, 0, 0, 0.15) 0px 0px 4px 0px;
-}
-.toggle-btn input:checked + .slider {
-    background-color: #34C759;
-}
-.toggle-btn input:checked + .slider::before {
+  }
+  .toggle-btn input:checked + .slider {
+    background-color: #34c759;
+  }
+  .toggle-btn input:checked + .slider::before {
     transform: translateX(22px);
+  }
 }
+
+.react-modal-sheet-container.comment-list {
+  height: 548px !important;
+}
+
+.react-modal-sheet-container.bottom-sheet {
+  height: 187px !important;
+}
+
+.bottom-open {
+  top: 0 !important;
+  bottom: 100px !important;
+  left: 0 !important;
+  right: 0 !important;
 }
 
 /* button 클래스 */

--- a/src/app/groups/[id]/_components/CommentCard.tsx
+++ b/src/app/groups/[id]/_components/CommentCard.tsx
@@ -130,8 +130,8 @@ const CommentCard = ({ comment, postId }: CommentCardProps) => {
           <span className="text-xs font-normal leading-[140%] text-gray-500">{formatTimeAgo(comment.created_at)}</span>
         </div>
         {user && user.id === comment.user_id && <Menu className="w-6 h-6 cursor-pointer" onClick={handleSheetOpen} />}
-        <BottomSheet isOpen={openSheet} onClose={handleSheetClose} snapPoint={[0.25]}>
-          <div className="w-full h-full bg-white rounded-xl divide-y flex flex-col justify-start overflow-hidden">
+        <BottomSheet isOpen={openSheet} onClose={handleSheetClose} snapPoint={[0.2]}>
+          <div className="w-full h-28 bg-white rounded-xl divide-y flex flex-col justify-start overflow-hidden">
             <Button
               type="button"
               label="수정하기"
@@ -151,7 +151,8 @@ const CommentCard = ({ comment, postId }: CommentCardProps) => {
           </div>
         </BottomSheet>
       </div>
-      <div className="mt-2">
+      {/* // 여기 클래스 수정함 */}
+      <div>
         <p className="text-sm font-normal leading-[140%] text-gray-900 pl-11 whitespace-pre-wrap break-words">
           {comment.content}
         </p>

--- a/src/app/groups/[id]/_components/CommentList.tsx
+++ b/src/app/groups/[id]/_components/CommentList.tsx
@@ -17,8 +17,8 @@ const CommentList = ({ isOpen, onClose, postId }: CommentListProps) => {
   const { isActionModalOpen } = useBottomSheetStore();
 
   return (
-    <Sheet isOpen={isOpen} onClose={onClose} snapPoints={isActionModalOpen ? [0.9] : [0.6]}>
-      <Sheet.Container>
+    <Sheet isOpen={isOpen} onClose={onClose} className={`${isActionModalOpen ? 'bottom-open transition-all' : ''}`}>
+      <Sheet.Container className="comment-list">
         <Sheet.Header>
           <div className="w-[5.625rem] h-[0.375rem] rounded-xl mx-auto mt-[0.563rem] bg-[#e4e4e7]" />
           <h3 className="w-full mx-auto mt-9 text-xl text-center font-bold leading-[140%]">댓글</h3>

--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -10,12 +10,12 @@ interface BottomSheetProps {
 const BottomSheet = ({ children, isOpen, onClose, snapPoint }: BottomSheetProps) => {
   return (
     <Sheet isOpen={isOpen} onClose={onClose} snapPoints={snapPoint}>
-      <Sheet.Container>
-        <Sheet.Header>
+      <Sheet.Container className="bottom-sheet">
+        <Sheet.Header className="mb-[21px]">
           <div className="w-12 h-1 bg-gray-300 rounded-full mx-auto mt-3" />
         </Sheet.Header>
         <Sheet.Content>
-          <div className="w-full h-full p-5">{children}</div>
+          <div className="w-full h-full p-5 flex items-center justify-center">{children}</div>
         </Sheet.Content>
       </Sheet.Container>
       <Sheet.Backdrop onTap={onClose} />

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 
-import { useRouter } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 
 import { Notification, PrevArrow, Setting } from '@components/icons';
 
@@ -18,9 +18,16 @@ interface HeaderProps {
 const Header = ({ home = false, label, hasSetting, isScrolled }: HeaderProps) => {
   const router = useRouter();
 
-  const handleNavigation = () => router.back();
+  const { id } = useParams();
+  const groupId = Array.isArray(id) ? id[0] : id;
 
   const { groupName } = useHeaderStore();
+
+  const handleNavigation = () => router.back();
+
+  const handleGroupManagement = (groupId: string) => {
+    router.push(`/groups/${groupId}/management`);
+  };
 
   return (
     <header
@@ -30,7 +37,7 @@ const Header = ({ home = false, label, hasSetting, isScrolled }: HeaderProps) =>
         {home ? (
           <Image src="/icons/modakLogo.webp" width={80} height={34} alt="Modak Modak Logo" className="w-20 h-10" />
         ) : (
-          <div className="w-20 p-2 flex items-center justify-start">
+          <div className={`${!hasSetting ? 'w-10' : 'w-20'} flex items-center justify-start`}>
             <PrevArrow onClick={handleNavigation} className="w-6 h-6" />
           </div>
         )}
@@ -47,7 +54,7 @@ const Header = ({ home = false, label, hasSetting, isScrolled }: HeaderProps) =>
             <Notification className="cursor-pointer" />
           </div>
           {hasSetting && (
-            <div className="w-10 p-2">
+            <div className="w-10 p-2" onClick={() => handleGroupManagement(groupId)}>
               <Setting className="cursor-pointer" />
             </div>
           )}


### PR DESCRIPTION
## Title

- feat: Header 컴포넌트 셋팅 버튼 클릭시 페이지 이동 적용 및 댓글 스타일 수정

## Changes

- Header 컴포넌트 세팅 아이콘 클릭 시 해당 그룹 관리 페이지로 이동할 수 있도록 변경했습니다.
- 댓글 컴포넌트 위치 global.css에! important로 정의해두었습니다. (클래스 명 붙여서 작업하면 될 것 같습니다.)

## PR 생성 날짜

- 2025.01.20

## CheckList

- [x] 불필요한 주석이 남아 있지는 않은가요?
- [x] 테스트 할 때 사용했던 console.log 가 남아있지 않은가요?
- [x] 코드 컨벤션이 잘 지켜져 있나요?
