### PR TITLE
feat: Comment 입력창 포커스시 해당 뷰포트 하단으로 이동 추가

### DIFF
--- a/src/app/groups/[id]/_components/CommentInput.tsx
+++ b/src/app/groups/[id]/_components/CommentInput.tsx
@@ -27,6 +27,12 @@ const CommentInput = ({ postId }: CommentInputProps) => {
 
   const queryClient = useQueryClient();
 
+  const handleFocus = () => {
+    if (textAreaRef.current) {
+      textAreaRef.current.scrollIntoView({ behavior: 'smooth', block: 'end' });
+    }
+  };
+
   const handleInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const value = e.target.value;
     setCommentValue(value);
@@ -75,7 +81,7 @@ const CommentInput = ({ postId }: CommentInputProps) => {
       <div className="w-[92%] bg-white absolute bottom-[25%] left-1/2 transform translate-x-[-50%] px-3 py-2 border rounded-lg h-auto flex items-center gap-2">
         <textarea
           rows={1}
-          autoFocus
+          onFocus={handleFocus}
           ref={textAreaRef}
           value={commentValue}
           onChange={handleInput}


### PR DESCRIPTION
## Title

- feat: Comment 입력창 포커스시 해당 뷰포트 하단으로 이동 추가

## Changes

- scrollIntoView를 사용해서 포커스 발생 시 이동할 수 있도록 해봤습니다.
- IOS에서는 scrollIntoView의 일부 옵션이 동작하지 않을 수 있다고 해서 확인해 봐야 할 것 같습니다.

## PR 생성 날짜

- 2025.01.21

## CheckList

- [x] 불필요한 주석이 남아 있지는 않은가요?
- [x] 테스트 할 때 사용했던 console.log 가 남아있지 않은가요?
- [x] 코드 컨벤션이 잘 지켜져 있나요?
