### PR TITLE
fix: 참여 신청 화면 분기 삭제, 멤버추가 스몰얼럿 2번 뜨는 버그 해결

### DIFF
--- a/src/app/_components/HomeGroupListSection.tsx
+++ b/src/app/_components/HomeGroupListSection.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import GroupList from '@app/_components/GroupList';
 import NoGroup from '@app/_components/NoGroup';
 import GlobalLoading from '@app/GlobalLoading';
@@ -8,19 +7,11 @@ import useFetchGroupList from '@hooks/home/useFetchGroupList';
 import useFetchWaitingGroupList from '@hooks/home/useFetchWaitingGroupList';
 
 const HomeGroupListSection = () => {
-  const [isLoading, setIsLoading] = useState(true);
 
-  const { data: groupDataList, isPending: groupDataListPending } = useFetchGroupList();
-  const { data: waitingGroupDataList, isPending: waitingListPending } = useFetchWaitingGroupList();
+  const { data: groupDataList } = useFetchGroupList();
+  const { data: waitingGroupDataList } = useFetchWaitingGroupList();
 
-  useEffect(() => {
-    if (!groupDataListPending && !waitingListPending) 
-      setTimeout(() => {
-        setIsLoading(false);
-      }, 1000);
-  }, [groupDataListPending, waitingListPending]);
-
-  if (isLoading) return <GlobalLoading />;
+  if (groupDataList === undefined && waitingGroupDataList === undefined) return <GlobalLoading />;
 
   return (
     <>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -83,6 +83,10 @@
   height: 187px !important;
 }
 
+.react-modal-sheet-container.management {
+  height: 130px !important;
+}
+
 .bottom-open {
   top: 0 !important;
   bottom: 100px !important;

--- a/src/app/groups/[id]/management/_components/modal/changeGroupProfile/ChangeGroupProfileModal.tsx
+++ b/src/app/groups/[id]/management/_components/modal/changeGroupProfile/ChangeGroupProfileModal.tsx
@@ -66,7 +66,13 @@ const ChangeGroupProfileModal = () => {
         <div className="m-auto w-24 h-24 relative">
           <div className="w-full h-full rounded-xl overflow-hidden flex items-center justify-center">
             {groupProfileImgUrl.length ? (
-              <Image src={groupProfileImgUrl} alt={'그룹 프로필'} width={100} height={100} className="w-full h-full" />
+              <Image
+                src={groupProfileImgUrl}
+                alt={'그룹 프로필'}
+                width={100}
+                height={100}
+                className="w-full h-full object-cover"
+              />
             ) : (
               <div className="w-full h-full bg-gray-400"></div>
             )}
@@ -93,10 +99,7 @@ const ChangeGroupProfileModal = () => {
         />
       </div>
       <div className="w-full mt-6 flex gap-2 justify-center">
-        <ProfileConfirmBtns
-          onConfirm={onConfirmUpdate}
-          disabled={!!(groupName === '' || description === '')}
-        />
+        <ProfileConfirmBtns onConfirm={onConfirmUpdate} disabled={!!(groupName === '' || description === '')} />
       </div>
     </div>
   );

--- a/src/app/groups/[id]/management/members/_components/CurMemberList.tsx
+++ b/src/app/groups/[id]/management/members/_components/CurMemberList.tsx
@@ -40,7 +40,7 @@ const CurMemberList = ({ isLeaderUser }: CurMemberListProps) => {
           <span className="text-primary">{curMemberList ? curMemberList.others.length + 1 : '...'}</span>
         </div>
       </div>
-      <div>
+      <div className='divide-y divide-gray-200'>
         {curMemberList && (
           <>
             {isLeaderUser ? (

--- a/src/app/groups/[id]/management/members/_components/CurMemberList.tsx
+++ b/src/app/groups/[id]/management/members/_components/CurMemberList.tsx
@@ -6,13 +6,6 @@ import GlobalLoading from '@app/GlobalLoading';
 import GlobalError from '@app/GlobalError';
 import useFetchCurMembers from '@hooks/management/useFetchCurMembers';
 
-const DEFAULTDATA = {
-  group_id: '',
-  is_approved: true,
-  is_leader: false,
-  users: { id: '', nickname: '', profile_image: '' },
-};
-
 interface CurMemberListProps {
   isLeaderUser: boolean;
 }
@@ -21,13 +14,14 @@ const CurMemberList = ({ isLeaderUser }: CurMemberListProps) => {
   const groupId = Array.isArray(id) ? id[0] : id;
 
   const { data: curMemberList, isPending, isError } = useFetchCurMembers({ groupId });
-  if (isPending) return <GlobalLoading/>;
-  if (isError) return <GlobalError/>;
+
+  if (isPending) return <GlobalLoading />;
+  if (isError) return <GlobalError />;
 
   //유저가 대표가 아닐 때 멤버 데이터에서 대표 데이터를 뽑아내기
   const filteredLeaderData =
     isLeaderUser || !curMemberList ? null : curMemberList.others.find((member) => member.is_leader === true);
-  const leaderData = filteredLeaderData ? filteredLeaderData : DEFAULTDATA;
+  const leaderData = filteredLeaderData;
 
   //대표를 제외한 멤버들의 데이터
   const filteredData = !curMemberList ? null : curMemberList.others.filter((member) => member.is_leader !== true);
@@ -40,7 +34,7 @@ const CurMemberList = ({ isLeaderUser }: CurMemberListProps) => {
           <span className="text-primary">{curMemberList ? curMemberList.others.length + 1 : '...'}</span>
         </div>
       </div>
-      <div className='divide-y divide-gray-200'>
+      <div className="divide-y divide-gray-200">
         {curMemberList && (
           <>
             {isLeaderUser ? (
@@ -56,7 +50,9 @@ const CurMemberList = ({ isLeaderUser }: CurMemberListProps) => {
             ) : (
               <>
                 <MemberCard memberData={curMemberList.me} isLeaderUser={isLeaderUser} mode={'curMembers'} isMe={true} />
-                <MemberCard memberData={leaderData} isLeaderUser={isLeaderUser} mode={'curMembers'} isLeader={true} />
+                {leaderData && (
+                  <MemberCard memberData={leaderData} isLeaderUser={isLeaderUser} mode={'curMembers'} isLeader={true} />
+                )}
               </>
             )}
             {filteredData?.map((member) => (

--- a/src/app/groups/[id]/management/members/_components/ManageMembersBtn.tsx
+++ b/src/app/groups/[id]/management/members/_components/ManageMembersBtn.tsx
@@ -19,7 +19,9 @@ const ManageMembersBtn = ({ memberId }: ManageMembersBtnProps) => {
 
   return (
     <button onClick={onOpenBottomSheet}>
-      <Menu />
+      <div className='w-[40px] h-[40px] flex justify-center items-center'>
+        <Menu />
+      </div>
     </button>
   );
 };

--- a/src/app/groups/[id]/management/members/_components/MemberCard.tsx
+++ b/src/app/groups/[id]/management/members/_components/MemberCard.tsx
@@ -6,7 +6,6 @@ import { CurMemberType } from '@queries/management/fetchMembers';
 
 interface MemberCardProps {
   memberData: CurMemberType;
-  toastOpener?: () => void;
   isLeaderUser: boolean;
   isLeader?: boolean;
   isMe?: boolean;
@@ -14,7 +13,6 @@ interface MemberCardProps {
 }
 const MemberCard = ({
   memberData,
-  toastOpener,
   isLeaderUser,
   isLeader = false,
   isMe = false,
@@ -28,7 +26,13 @@ const MemberCard = ({
       <div className="px-5 h-16 flex bg-gray-100 justify-between items-center">
         <div className="flex gap-4">
           <div className="w-8 h-8 rounded-full overflow-hidden">
-            <Image src={profile} width={56} height={56} alt={'member_profile'} className="rounded-full w-full h-full" />
+            <Image
+              src={profile}
+              width={56}
+              height={56}
+              alt={'member_profile'}
+              className="rounded-full w-full h-full object-cover"
+            />
           </div>
           <span className="flex items-center gap-1">
             {nickname} {isMe && <span className="text-gray-500 text-sm">{'(나)'}</span>}
@@ -39,10 +43,15 @@ const MemberCard = ({
             memberId={memberData.users.id}
             isLeader={isLeader}
             mode={mode}
-            toastOpener={toastOpener ? toastOpener : null}
           />
         ) : (
-          <>{mode === 'curMembers' && isLeader && <span className="text-primary">대표</span>}</>
+          <>
+            {mode === 'curMembers' && isLeader && (
+              <div className="w-[40px] h-[40px] flex justify-center items-center">
+                <span className="text-primary">대표</span>
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/src/app/groups/[id]/management/members/_components/MemberCardLeaderBtns.tsx
+++ b/src/app/groups/[id]/management/members/_components/MemberCardLeaderBtns.tsx
@@ -5,22 +5,23 @@ import ManageMembersBtn from '@app/groups/[id]/management/members/_components/Ma
 import usePermitNewMember from '@hooks/management/usePermitNewMember';
 import useRefuseNewMember from '@hooks/management/useRefuseNewMember';
 import { UsersType } from '@ts/supabaseTableRowTypes';
+import useUserToManageStore from '@stores/useUserToManage';
 
 interface MemberCardBtnsProps {
   memberId: UsersType['id'];
-  toastOpener: (() => void) | null;
   isLeader: boolean;
   mode: 'curMembers' | 'waiting';
 }
-const MemberCardLeaderBtns = ({ memberId, isLeader, mode, toastOpener }: MemberCardBtnsProps) => {
+const MemberCardLeaderBtns = ({ memberId, isLeader, mode }: MemberCardBtnsProps) => {
   const { id } = useParams();
   const groupId = Array.isArray(id) ? id[0] : id;
+  const { setUserPermitted } = useUserToManageStore();
   const permitNewMember = usePermitNewMember({ groupId, waitingUserId: memberId });
   const refuseNewMember = useRefuseNewMember({ groupId, waitingUserId: memberId });
 
   const onPermit = async () => {
     permitNewMember();
-    if (toastOpener) toastOpener();
+    setUserPermitted(true);
   };
 
   const onRefuse = async () => {
@@ -30,7 +31,13 @@ const MemberCardLeaderBtns = ({ memberId, isLeader, mode, toastOpener }: MemberC
   return (
     <>
       {mode === 'curMembers' &&
-        (isLeader ? <span className="text-primary">대표</span> : <ManageMembersBtn memberId={memberId} />)}
+        (isLeader ? (
+          <div className="w-[40px] h-[40px] flex justify-center items-center">
+            <span className="text-primary">대표</span>
+          </div>
+        ) : (
+          <ManageMembersBtn memberId={memberId} />
+        ))}
       {mode === 'waiting' && (
         <div>
           <button type="button" onClick={onRefuse}>

--- a/src/app/groups/[id]/management/members/_components/MembersBottomSheet.tsx
+++ b/src/app/groups/[id]/management/members/_components/MembersBottomSheet.tsx
@@ -20,8 +20,8 @@ const MembersBottomSheet = () => {
   };
 
   return (
-    <BottomSheet isOpen={isActionModalOpen} onClose={onCloseBottomSheet} snapPoint={[0.16]}>
-      <div className="my-5 rounded-xl overflow-hidden divide-y divide-gray-200">
+    <BottomSheet isOpen={isActionModalOpen} onClose={onCloseBottomSheet} className="management">
+      <div className="my-5 w-full rounded-xl overflow-hidden divide-y divide-gray-200">
         <div className="bg-gray-100">
           <Button
             type={'button'}

--- a/src/app/groups/[id]/management/members/_components/MembersPageContents.tsx
+++ b/src/app/groups/[id]/management/members/_components/MembersPageContents.tsx
@@ -1,15 +1,17 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
+import useUserToManageStore from '@stores/useUserToManage';
 import CurMemberList from '@app/groups/[id]/management/members/_components/CurMemberList';
 import WaitingMemberList from '@app/groups/[id]/management/members/_components/WaitingMemberList';
 import MembersBottomSheet from '@app/groups/[id]/management/members/_components/MembersBottomSheet';
 import ManagementModal from '@app/groups/[id]/management/_components/modal/ManagementModal';
 import GlobalLoading from '@app/GlobalLoading';
 import GlobalError from '@app/GlobalError';
+import { AddMember } from '@components/icons';
 import useIsLeader from '@hooks/management/useIsLeader';
-
+import useSmallAlert from '@hooks/useSmallAlert';
 
 type TabType = 'currentMembers' | 'awaitingMembers';
 
@@ -18,6 +20,8 @@ const MembersPageContents = () => {
   const groupId = Array.isArray(id) ? id[0] : id;
 
   const [selectedTab, setSelectedTab] = useState<TabType>('currentMembers');
+  const { userPermitted, setUserPermitted } = useUserToManageStore();
+  const { SmallAlert: MemberAddedAlert, openAlert } = useSmallAlert();
 
   const handleCurMemTabClick = () => {
     setSelectedTab('currentMembers');
@@ -28,8 +32,16 @@ const MembersPageContents = () => {
   };
 
   const { data: isLeaderUser, isPending, isError } = useIsLeader({ groupId });
-  if (isPending) return <GlobalLoading/>;
-  if (isError) return <GlobalError/>;
+
+  useEffect(() => {
+    if (userPermitted) {
+      setUserPermitted(false);
+      openAlert();
+    }
+  }, [userPermitted]);
+
+  if (isPending) return <GlobalLoading />;
+  if (isError) return <GlobalError />;
 
   return (
     <>
@@ -57,6 +69,12 @@ const MembersPageContents = () => {
       )}
       <ManagementModal isLeader={isLeaderUser ? isLeaderUser : false} modalMode={'leaderTransition'} />
       <MembersBottomSheet />
+      <MemberAddedAlert>
+        <div className="flex gap-2.5">
+          <AddMember />
+          <span>{'멤버가 추가 되었어요!'}</span>
+        </div>
+      </MemberAddedAlert>
     </>
   );
 };

--- a/src/app/groups/[id]/management/members/_components/WaitingMemberList.tsx
+++ b/src/app/groups/[id]/management/members/_components/WaitingMemberList.tsx
@@ -4,9 +4,7 @@ import { useParams } from 'next/navigation';
 import MemberCard from '@app/groups/[id]/management/members/_components/MemberCard';
 import GlobalLoading from '@app/GlobalLoading';
 import GlobalError from '@app/GlobalError';
-import { AddMember } from '@components/icons';
 import useFetchWaitingMembers from '@hooks/management/useFetchWaitingMembers';
-import useSmallAlert from '@hooks/useSmallAlert';
 
 interface WaitingMemberListProps {
   isLeaderUser: boolean;
@@ -14,13 +12,6 @@ interface WaitingMemberListProps {
 const WaitingMemberList = ({ isLeaderUser }: WaitingMemberListProps) => {
   const { id } = useParams();
   const groupId = Array.isArray(id) ? id[0] : id;
-  const { SmallAlert: MemberAddedAlert, openAlert } = useSmallAlert();
-
-  const OpenMemberAddedAlert = () => {
-    setTimeout(() => {
-      openAlert(); // 쿼리 데이터 업데이트로 인한 리렌더링 이후 열림
-    }, 800);
-  };
 
   const { data, isPending, isError } = useFetchWaitingMembers({ groupId });
 
@@ -35,25 +26,14 @@ const WaitingMemberList = ({ isLeaderUser }: WaitingMemberListProps) => {
             <span>대기 멤버</span> <span className="text-primary">{data ? data.length : 0}</span>
           </div>
         </div>
-        <div>
+        <div className="divide-y divide-gray-200">
           {data &&
             data.map((member) => (
-              <MemberCard
-                key={member.users.id}
-                memberData={member}
-                isLeaderUser={isLeaderUser}
-                mode={'waiting'}
-                toastOpener={OpenMemberAddedAlert}
-              />
+              <MemberCard key={member.users.id} memberData={member} isLeaderUser={isLeaderUser} mode={'waiting'} />
             ))}
         </div>
       </div>
-      <MemberAddedAlert>
-        <div className="flex gap-2.5">
-          <AddMember />
-          <span>{'멤버가 추가 되었어요!'}</span>
-        </div>
-      </MemberAddedAlert>
+
     </>
   );
 };

--- a/src/app/join/[id]/_components/NonUserQueryJoin.tsx
+++ b/src/app/join/[id]/_components/NonUserQueryJoin.tsx
@@ -1,40 +1,26 @@
 'use client';
 
 import { useParams, useRouter } from 'next/navigation';
-import Image from 'next/image';
-
 import Button from '@components/common/Button';
+import { useFetchGetGroup } from '@hooks/useFetchGetGroup';
+import QueryJoinContents from '@app/join/[id]/_components/QueryJoinContents';
 
 const NonUserQueryJoin = () => {
   const router = useRouter();
   const { id } = useParams();
   const groupId = Array.isArray(id) ? id[0] : id;
+  const { data: groupInfo } = useFetchGetGroup(groupId);
   const onQueryJoin = () => {
     router.push(`/login?referrer=join&data=${groupId}`);
   };
 
   return (
     <>
-      <div className="w-full h-full bg-primary-10 flex flex-col justify-center gap-9">
-        <div className="text-center">
-          <h4 className="text-gray-800 text-2xl font-bold mb-5">모임에 초대되셨어요!</h4>
-          <span className="block text-lg text-gray-700 mb-11">
-            모임에 가입하고
-            <br />
-            추억을 자유롭게 공유해주세요
-          </span>
-          <Image
-            width={168}
-            height={168}
-            src="/icons/join-hand-with-heart.webp"
-            alt="join-page-icon"
-            className="m-auto"
-          />
-        </div>
-        <div className="px-5 w-full absolute bottom-0">
+      {groupInfo && (
+        <QueryJoinContents groupInfo={groupInfo}>
           <Button type="button" className="full-btn" onClick={onQueryJoin} label="로그인하고 모임 가입하기" />
-        </div>
-      </div>
+        </QueryJoinContents>
+      )}
     </>
   );
 };

--- a/src/app/join/[id]/_components/QueryJoinContents.tsx
+++ b/src/app/join/[id]/_components/QueryJoinContents.tsx
@@ -1,0 +1,39 @@
+import Image from "next/image";
+import GroupCard, { GroupCardInfosType } from "@components/common/groupCard/GroupCard";
+
+interface QueryJoinContentsProps {
+  groupInfo: GroupCardInfosType;
+  children: React.ReactNode;
+}
+
+const QueryJoinContents = ({ groupInfo, children }: QueryJoinContentsProps) => {
+  return (
+    <div className="pt-[48px] w-full h-full bg-primary-10 flex flex-col justify-end gap-9">
+      <div className="text-center">
+        <Image
+          width={100}
+          height={100}
+          src="/icons/join-hand-with-heart.webp"
+          alt="join-page-icon"
+          className="m-auto mb-8"
+        />
+        <h4 className="text-gray-800 text-2xl font-bold mb-5">모임에 초대되셨어요!</h4>
+        <span className="text-lg text-gray-700">
+          모임에 가입하고
+          <br />
+          추억을 자유롭게 공유해주세요
+        </span>
+      </div>
+      <div className="w-full h-[45vh] rounded-t-[1.25rem] bg-white">
+        {groupInfo && (
+          <div className="px-5 pt-5">
+            <h6 className="text-gray-500 mb-3">초대된 모임</h6> <GroupCard groupInfo={groupInfo} hasLink={false} />
+          </div>
+        )}
+        <div className="px-5 w-full absolute bottom-0">{children}</div>
+      </div>
+    </div>
+  );
+};
+
+export default QueryJoinContents

--- a/src/app/join/[id]/_components/UserQueryJoinStepOne.tsx
+++ b/src/app/join/[id]/_components/UserQueryJoinStepOne.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import Image from 'next/image';
 import { useParams } from 'next/navigation';
 import Button from '@components/common/Button';
-import GroupCard from '@components/common/groupCard/GroupCard';
 import { useFetchGetGroup } from '@hooks/useFetchGetGroup';
+import QueryJoinContents from '@app/join/[id]/_components/QueryJoinContents';
 
 interface UserQueryJoinStepOneProps {
   onQueryJoin: () => void;
@@ -17,37 +16,17 @@ const UserQueryJoinStepOne = ({ onQueryJoin, buttonLabel, isJoinable }: UserQuer
   const { data: groupInfo } = useFetchGetGroup(groupId);
 
   return (
-    <div className="pt-[48px] w-full h-full bg-primary-10 flex flex-col justify-end gap-9">
-      <div className="text-center">
-        <Image
-          width={100}
-          height={100}
-          src="/icons/join-hand-with-heart.webp"
-          alt="join-page-icon"
-          className="m-auto mb-8"
-        />
-        <h4 className="text-gray-800 text-2xl font-bold mb-5">모임에 초대되셨어요!</h4>
-        <span className="text-lg text-gray-700">
-          모임에 가입하고
-          <br />
-          추억을 자유롭게 공유해주세요
-        </span>
-      </div>
-      <div className="w-full h-[45vh] rounded-t-[1.25rem] bg-white">
-        {groupInfo && (
-          <div className="px-5 pt-5">
-            <h6 className="text-gray-500 mb-3">초대된 모임</h6> <GroupCard groupInfo={groupInfo} hasLink={false} />
-          </div>
-        )}
-        <div className="px-5 w-full absolute bottom-0">
+    <>
+      {groupInfo && (
+        <QueryJoinContents groupInfo={groupInfo}>
           {isJoinable ? (
             <Button type="button" className="full-btn" onClick={onQueryJoin} label={buttonLabel} />
           ) : (
             <Button type="button" className="full-btn" onClick={onQueryJoin} label={buttonLabel} disabled={true} />
           )}
-        </div>
-      </div>
-    </div>
+        </QueryJoinContents>
+      )}
+    </>
   );
 };
 

--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -3,14 +3,15 @@ import { Sheet } from 'react-modal-sheet';
 interface BottomSheetProps {
   isOpen: boolean;
   onClose: () => void;
-  snapPoint: number[];
+  snapPoint?: number[];
+  className?: string;
   children: React.ReactNode;
 }
 
-const BottomSheet = ({ children, isOpen, onClose, snapPoint }: BottomSheetProps) => {
+const BottomSheet = ({ children, isOpen, onClose, snapPoint, className }: BottomSheetProps) => {
   return (
     <Sheet isOpen={isOpen} onClose={onClose} snapPoints={snapPoint}>
-      <Sheet.Container className="bottom-sheet">
+      <Sheet.Container className={className ? className : 'bottom-sheet'}>
         <Sheet.Header className="mb-[21px]">
           <div className="w-12 h-1 bg-gray-300 rounded-full mx-auto mt-3" />
         </Sheet.Header>

--- a/src/components/common/groupCard/GroupCardContent.tsx
+++ b/src/components/common/groupCard/GroupCardContent.tsx
@@ -18,7 +18,7 @@ const GroupCardContent = ({ groupInfo, hasLink = true }: GroupCardContentProps) 
           <Image
             width={100}
             height={100}
-            className="w-full h-full"
+            className="w-full h-full object-cover"
             src={`${image_url}`}
             alt="group_profile"
             priority={!hasLink}

--- a/src/stores/useUserToManage.ts
+++ b/src/stores/useUserToManage.ts
@@ -2,12 +2,18 @@ import { create } from 'zustand';
 import { UsersType } from '@ts/supabaseTableRowTypes';
 
 type UserToManageStoreType = {
+  userPermitted: boolean;
   selectedUser: UsersType['id'];
+  setUserPermitted: (bool: boolean) => void;
   setSelectedUser: (userId: UsersType['id']) => void;
 };
 
 const useUserToManageStore = create<UserToManageStoreType>((set) => ({
+  userPermitted: false,
   selectedUser: '',
+  setUserPermitted: (bool) => {
+    set({ userPermitted: bool });
+  },
   setSelectedUser: (userId) => set({ selectedUser: userId }),
 }));
 


### PR DESCRIPTION
## Title

-fix: 참여 신청 화면 분기 삭제, 멤버추가 스몰얼럿 2번 뜨는 버그 해결

## Changes

버그픽스
-멤버추가 스몰얼럿이 2번 뜨는 버그를 해결했습니다.
-대표 양도 시 유령 멤버 생기던 문제를 해결했습니다.
-홈 화면 로딩 깜빡임을 근본적으로 해결했습니다. 
(아직 모임이 없어요가 뜬 뒤 모임 리스트가 뜨는 문제도 엮여있었던 버그였기에 해당 문제도 함께 해결되었습니다.)

스타일링 관련
-참여 신청 화면이 로그인, 비로그인 유저로 분기되던 걸 삭제하였습니다.
-멤버 양도 bottom sheet의 높이를 절대값으로 수정했습니다.
-공용 컴포넌트 bottom sheet를 클래스 네임을 props로 받을 수 있도록 수정했습니다.
-멤버 양도 버튼의 터치영역을 40X40픽셀로 수정하고, 그룹 프로필 수정, 멤버 정보, 모임방 카드에서 사용하는 
이미지를 그리는 방식을 수정하였습니다.

## PR 생성 날짜

- 2025.01.21

## CheckList

- [x] 불필요한 주석이 남아 있지는 않은가요?
- [x] 테스트 할 때 사용했던 console.log 가 남아있지 않은가요?
- [ ] 코드 컨벤션이 잘 지켜져 있나요?
