### PR TITLE
feat: visualViewport를 통한 Sheet.Container 높이 조절 및 IOS 환경에서만 resize 이벤트 등록

### DIFF
--- a/src/app/groups/[id]/_components/CommentInput.tsx
+++ b/src/app/groups/[id]/_components/CommentInput.tsx
@@ -27,12 +27,6 @@ const CommentInput = ({ postId }: CommentInputProps) => {
 
   const queryClient = useQueryClient();
 
-  const handleFocus = () => {
-    if (textAreaRef.current) {
-      textAreaRef.current.scrollIntoView({ behavior: 'smooth', block: 'end' });
-    }
-  };
-
   const handleInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const value = e.target.value;
     setCommentValue(value);
@@ -81,7 +75,6 @@ const CommentInput = ({ postId }: CommentInputProps) => {
       <div className="w-[92%] bg-white absolute bottom-[25%] left-1/2 transform translate-x-[-50%] px-3 py-2 border rounded-lg h-auto flex items-center gap-2">
         <textarea
           rows={1}
-          onFocus={handleFocus}
           ref={textAreaRef}
           value={commentValue}
           onChange={handleInput}

--- a/src/app/groups/[id]/_components/CommentList.tsx
+++ b/src/app/groups/[id]/_components/CommentList.tsx
@@ -19,23 +19,28 @@ const CommentList = ({ isOpen, onClose, postId }: CommentListProps) => {
   const [keyboardHeight, setKeyboardHeight] = useState(0);
 
   useEffect(() => {
-    const handleResize = () => {
-      const visualViewportHeight = window.visualViewport?.height || window.innerHeight;
-      const windowHeight = window.innerHeight;
-      const newKeyboardHeight = windowHeight - visualViewportHeight;
+    const handleVisualViewportResize = () => {
+      if (!window.visualViewport) return;
+
+      const layoutViewportHeight = window.innerHeight;
+      const visualViewportHeight = window.visualViewport.height;
+      const newKeyboardHeight = Math.max(0, layoutViewportHeight - visualViewportHeight);
+
       setKeyboardHeight(newKeyboardHeight);
     };
 
-    window.visualViewport?.addEventListener('resize', handleResize);
+    window.visualViewport?.addEventListener('resize', handleVisualViewportResize);
+
     return () => {
-      window.visualViewport?.removeEventListener('resize', handleResize);
+      window.visualViewport?.removeEventListener('resize', handleVisualViewportResize);
     };
   }, []);
 
   return (
     <Sheet isOpen={isOpen} onClose={onClose} className={`${isActionModalOpen ? 'bottom-open transition-all' : ''}`}>
       <Sheet.Container
-        className={`comment-list transition-all ${keyboardHeight > 0 ? `!bottom-[${keyboardHeight}]` : '0'}`}
+        className="comment-list transition-all"
+        style={{ bottom: keyboardHeight > 0 ? keyboardHeight : 0 }}
       >
         <Sheet.Header>
           <div className="w-[5.625rem] h-[0.375rem] rounded-xl mx-auto mt-[0.563rem] bg-[#e4e4e7]" />

--- a/src/app/groups/[id]/_components/CommentList.tsx
+++ b/src/app/groups/[id]/_components/CommentList.tsx
@@ -29,10 +29,17 @@ const CommentList = ({ isOpen, onClose, postId }: CommentListProps) => {
       setKeyboardHeight(newKeyboardHeight);
     };
 
-    window.visualViewport?.addEventListener('resize', handleVisualViewportResize);
+    // iOS 환경인지 확인
+    const isIOS = /iPhone|iPad/.test(window.navigator.userAgent);
+
+    if (isIOS) {
+      window.visualViewport?.addEventListener('resize', handleVisualViewportResize);
+    }
 
     return () => {
-      window.visualViewport?.removeEventListener('resize', handleVisualViewportResize);
+      if (isIOS) {
+        window.visualViewport?.removeEventListener('resize', handleVisualViewportResize);
+      }
     };
   }, []);
 


### PR DESCRIPTION
## Title

- feat: visualViewport를 통한 Sheet.Container 높이 조절 및 IOS 환경에서만 resize 이벤트 등록

## Changes

- visualViewport와 레이아웃 뷰포트를 계산해서 키보드 높이를 구하고 키보드 높이만큼 Sheet.Container를 올려주는 로직입니다.
- 안드로이드에서는 정상작동하기 때문에 운영체제가 ios인 경우에만 resize 이벤트를 등록할 수 있도록 했습니다.

## PR 생성 날짜

- 2025.01.49

## CheckList

- [x] 불필요한 주석이 남아 있지는 않은가요?
- [x] 테스트 할 때 사용했던 console.log 가 남아있지 않은가요?
- [x] 코드 컨벤션이 잘 지켜져 있나요?
