### PR TITLE
fix: 이미 가입된 멤버는 가입되지 않도록 수정

### DIFF
--- a/src/app/mypage/_components/modalContents/ProfileUpdateModalContent.tsx
+++ b/src/app/mypage/_components/modalContents/ProfileUpdateModalContent.tsx
@@ -81,7 +81,7 @@ const ProfileUpdateModalContent = () => {
         </div>
       </div>
       <div className="w-full mt-6 flex gap-2 justify-center">
-        <ProfileConfirmBtns onConfirm={onConfirmChange} />
+        <ProfileConfirmBtns disabled={!values.nickname} onConfirm={onConfirmChange} />
       </div>
     </div>
   );

--- a/src/queries/join/queryJoinGroup.ts
+++ b/src/queries/join/queryJoinGroup.ts
@@ -21,7 +21,7 @@ export const isAlreadyMember = async ({ groupId, userId }: QueryJoinGroupParams)
 export const queryJoinGroup = async ({ groupId, userId }: QueryJoinGroupParams) => {
   try {
     const supabase = await createClient();
-
+    if (await isAlreadyMember({ groupId, userId })) return;
     await supabase
       .from('group_members')
       .insert([{ group_id: groupId, is_approved: true, is_leader: false, user_id: userId }]);


### PR DESCRIPTION
## Title

- 모임 초대 플로우 중 로그인이 필요한 경우에 로그인 처리 후 이미 가입된 멤버는 가입되지 않도록 수정

## Changes

- 모임 초대 플로우 중 로그인이 필요한 경우에 로그인 처리 후 이미 가입된 멤버는 가입되지 않도록 수정했습니다.

## PR 생성 날짜

- 2025.01.24

## CheckList

- [x] 불필요한 주석이 남아 있지는 않은가요?
- [x] 테스트 할 때 사용했던 console.log 가 남아있지 않은가요?
- [x] 코드 컨벤션이 잘 지켜져 있나요?
