### PR TITLE
feat: IOS를 위한 global.css user-select 수정 및 IOS KeyBoard 높이에 따른 변경 hook 적용

### DIFF
--- a/src/app/chat/_components/ChatInput.tsx
+++ b/src/app/chat/_components/ChatInput.tsx
@@ -7,7 +7,6 @@ import { User } from '@supabase/supabase-js';
 import Button from '@components/common/Button';
 
 import useChatMessage from '@hooks/chat/useChatMessage';
-import useIOSKeyboardHeight from '@hooks/comment/useIOSKeyboardHeight';
 
 interface ChatInputProps {
   user: User | null;
@@ -16,8 +15,6 @@ interface ChatInputProps {
 
 const ChatInput = ({ user, chatRoomId }: ChatInputProps) => {
   const { message, setMessage, sendMessage, SmallAlert } = useChatMessage(chatRoomId as string, user?.id as string);
-
-  const keyboardHeight = useIOSKeyboardHeight();
 
   const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
 
@@ -54,9 +51,7 @@ const ChatInput = ({ user, chatRoomId }: ChatInputProps) => {
   };
 
   return (
-    <div
-      className={`px-5 pt-2 ${keyboardHeight > 0 ? `pb-[${keyboardHeight}px]` : 'pb-2'} absolute bottom-0 left-0 right-0 transition-all`}
-    >
+    <div className="px-5 py-2 absolute bottom-0 left-0 right-0 z-10">
       <div className="w-full border bg-white px-3 py-2 rounded-lg flex items-center gap-1">
         <textarea
           rows={1}

--- a/src/app/chat/_components/ChatRoom.tsx
+++ b/src/app/chat/_components/ChatRoom.tsx
@@ -66,7 +66,8 @@ const ChatRoom = ({ user, chatRoomId }: ChatRoomProps) => {
         type: 'response.create',
         response: {
           modalities: ['text'],
-          instructions: 'Please summarize the conversation.',
+          instructions:
+            'Please summarize the conversation. If you cannot understand the conversation or summarization is not possible, respond with: "The conversation cannot be summarized. Please check the conversation content."',
         },
       };
 

--- a/src/app/chat/_components/ChatRoomDetail.tsx
+++ b/src/app/chat/_components/ChatRoomDetail.tsx
@@ -7,6 +7,7 @@ import ChatRoom from '@app/chat/_components/ChatRoom';
 
 import FunnelHeader from '@components/common/FunnelHeader';
 
+import useIOSKeyboardHeight from '@hooks/comment/useIOSKeyboardHeight';
 import useGroupName from '@hooks/chat/useGroupName';
 import useUser from '@hooks/useUser';
 
@@ -17,8 +18,12 @@ const ChatRoomDetail = () => {
 
   const { chatGroupName } = useGroupName(chatRoomId as string);
 
+  const keyboardHeight = useIOSKeyboardHeight();
+
   return (
-    <div className="relative max-w-[600px] mx-auto border-x border-gray-200 w-full h-screen">
+    <div
+      className={`relative max-w-[600px] mx-auto border-x border-gray-200 w-full h-screen ${keyboardHeight > 0 ? `bottom-[${keyboardHeight}]px` : ''} transition-all`}
+    >
       <FunnelHeader label={chatGroupName?.name as string} />
       <ChatRoom user={user} chatRoomId={chatRoomId as string} />
       <ChatInput user={user} chatRoomId={chatRoomId as string} />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -76,16 +76,15 @@
     box-shadow: rgba(0, 0, 0, 0.15) 0px 0px 4px 0px;
   }
 
-  .toggle-btn input:checked+.slider {
+  .toggle-btn input:checked + .slider {
     background-color: #34c759;
   }
 
-  .toggle-btn input:checked+.slider::before {
+  .toggle-btn input:checked + .slider::before {
     transform: translateX(22px);
   }
 
   @media (min-width: 600px) {
-
     /*모달 배경색 가운데 정렬*/
     .modal-back-drop {
       width: 600px !important;
@@ -103,6 +102,15 @@
 
 body {
   padding-bottom: env(safe-area-inset-bottom);
+}
+
+/* IOS */
+input,
+textarea {
+  -moz-user-select: auto;
+  -webkit-user-select: auto;
+  -ms-user-select: auto;
+  user-select: auto;
 }
 
 .react-modal-sheet-container.comment-list {
@@ -125,7 +133,6 @@ body {
 }
 
 @media (min-width: 600px) {
-
   /*모달 배경색 가운데 정렬*/
   .modal-back-drop {
     width: 600px !important;
@@ -160,8 +167,7 @@ body {
 
   .floating-btn {
     @apply w-[124px] h-11 flex items-center justify-center gap-1 rounded-[20px] text-sm bg-primary font-semibold leading-[140%] text-white shadow-[0px_4px_4px_0px_#00000033] fixed bottom-[5.5rem]
-    /*right-5*/
-    ;
+    /*right-5*/;
   }
 
   .no-floating-btn {


### PR DESCRIPTION
## Title

- feat: IOS를 위한 global.css user-select 수정 및 IOS KeyBoard 높이에 따른 변경 hook 적용

## Changes

- IOS input, textarea 클릭 및 댓글 작성 안되는 문제를 수정하기 위해 user-select를 변경했습니다.
- 채팅 입력 시 가상 키보드가 내려간 후 입력창이 그대로 고정된 문제를 해결하기 위해 hook을 적용했습니다
- AI 요약 프롬프트를 추가했습니다. (대화 내용을 이해할 수 없다면 이해할 수 없다는 메세지를 출력해달라고 요청)

## PR 생성 날짜

- 2025.02.04

## CheckList

- [x] 불필요한 주석이 남아 있지는 않은가요?
- [x] 테스트 할 때 사용했던 console.log 가 남아있지 않은가요?
- [x] 코드 컨벤션이 잘 지켜져 있나요?
