### PR TITLE
fix: ChatInput 컴포넌트 onTouchStart 이벤트 삭제

### DIFF
--- a/src/app/chat/_components/ChatInput.tsx
+++ b/src/app/chat/_components/ChatInput.tsx
@@ -59,7 +59,6 @@ const ChatInput = ({ user, chatRoomId }: ChatInputProps) => {
           value={message}
           onChange={handleInput}
           onKeyDown={handleKeyDown}
-          onTouchStart={() => textAreaRef.current?.focus()}
           placeholder="메세지 입력하기.."
           className="resize-none border-none outline-none min-h-6 h-6 text-sm w-full"
         />

--- a/src/app/chat/_components/ChatInput.tsx
+++ b/src/app/chat/_components/ChatInput.tsx
@@ -51,7 +51,7 @@ const ChatInput = ({ user, chatRoomId }: ChatInputProps) => {
   };
 
   return (
-    <div className="px-5 py-2 absolute bottom-0 left-0 right-0 z-10">
+    <div className="px-5 py-2 absolute bottom-0 left-0 right-0 z-10 bg-white">
       <div className="w-full border bg-white px-3 py-2 rounded-lg flex items-center gap-1">
         <textarea
           rows={1}

--- a/src/app/chat/_components/ChatRoom.tsx
+++ b/src/app/chat/_components/ChatRoom.tsx
@@ -122,7 +122,7 @@ const ChatRoom = ({ user, chatRoomId }: ChatRoomProps) => {
   return (
     <div
       ref={chatRoomRef}
-      className="flex w-full flex-col overflow-y-auto h-[calc(100vh-48px-58px)] scroll-smooth scrollbar-hide"
+      className="flex w-full flex-col overflow-y-auto h-[calc(100vh-48px)] pb-[58px] scroll-smooth scrollbar-hide"
     >
       {messages?.length === 0 && <ChatEmptyMessage />}
       <ChatMessageList messages={messages} currentUserId={currentUserId as string} />

--- a/src/app/chat/_components/ChatRoomDetail.tsx
+++ b/src/app/chat/_components/ChatRoomDetail.tsx
@@ -22,8 +22,8 @@ const ChatRoomDetail = () => {
 
   return (
     <div
-      className="relative max-w-[600px] mx-auto border-x border-gray-200 w-full h-screen transition-all"
-      style={{ bottom: keyboardHeight > 0 ? `${keyboardHeight}px` : 0 }}
+      className="relative max-w-[600px] mx-auto border-x border-gray-200 w-full min-h-screen transition-all"
+      style={{ bottom: keyboardHeight > 0 ? keyboardHeight : 0 }}
     >
       <FunnelHeader label={chatGroupName?.name as string} />
       <ChatRoom user={user} chatRoomId={chatRoomId as string} />

--- a/src/app/groups/[id]/_components/CommentInput.tsx
+++ b/src/app/groups/[id]/_components/CommentInput.tsx
@@ -71,7 +71,7 @@ const CommentInput = ({ postId }: CommentInputProps) => {
   };
 
   return (
-    <div className="min-h-[20%] relative">
+    <div className="min-h-[20%] relative z-10">
       <div className="w-[92%] bg-white absolute bottom-[25%] left-1/2 transform translate-x-[-50%] px-3 py-2 border rounded-lg h-auto flex items-center gap-2">
         <textarea
           rows={1}


### PR DESCRIPTION
## Title

- fix: ChatInput 컴포넌트 onTouchStart 이벤트 삭제

## Changes

- ChatInput에 추가했던 onTouchStart 문제가 발생해서 삭제했습니다.
- 댓글 카드에서 z-index 추가했습니다.

## PR 생성 날짜

- 2025.02.04

## CheckList

- [x] 불필요한 주석이 남아 있지는 않은가요?
- [x] 테스트 할 때 사용했던 console.log 가 남아있지 않은가요?
- [x] 코드 컨벤션이 잘 지켜져 있나요?
