### PR TITLE
fix: 모임 멤버 화면 pb 처리

### DIFF
--- a/src/app/groups/[id]/management/members/_components/CurMemberList.tsx
+++ b/src/app/groups/[id]/management/members/_components/CurMemberList.tsx
@@ -34,46 +34,52 @@ const CurMemberList = ({ isLeaderUser }: CurMemberListProps) => {
           <span className="text-primary">{curMemberList ? curMemberList.others.length + 1 : '...'}</span>
         </div>
       </div>
-      <div className={`${curMemberList ? 'border-b border-gray-200' : ''}`}>
-        <div className="divide-y divide-gray-200">
-          {curMemberList && (
-            <>
-              {isLeaderUser ? (
-                <>
-                  <MemberCard
-                    memberData={curMemberList.me}
-                    isLeaderUser={isLeaderUser}
-                    mode={'curMembers'}
-                    isLeader={true}
-                    isMe={true}
-                  />
-                </>
-              ) : (
-                <>
-                  <MemberCard
-                    memberData={curMemberList.me}
-                    isLeaderUser={isLeaderUser}
-                    mode={'curMembers'}
-                    isMe={true}
-                  />
-                  {leaderData && (
+      <div className="pb-[128px]">
+        <div className={`${curMemberList ? 'border-b border-gray-200' : ''}`}>
+          <div className="divide-y divide-gray-200">
+            {curMemberList && (
+              <>
+                {isLeaderUser ? (
+                  <>
                     <MemberCard
-                      memberData={leaderData}
+                      memberData={curMemberList.me}
                       isLeaderUser={isLeaderUser}
                       mode={'curMembers'}
                       isLeader={true}
+                      isMe={true}
                     />
-                  )}
-                </>
-              )}
-              {filteredData?.map((member) => (
-                <MemberCard key={member.users.id} memberData={member} isLeaderUser={isLeaderUser} mode={'curMembers'} />
-              ))}
-            </>
-          )}
+                  </>
+                ) : (
+                  <>
+                    <MemberCard
+                      memberData={curMemberList.me}
+                      isLeaderUser={isLeaderUser}
+                      mode={'curMembers'}
+                      isMe={true}
+                    />
+                    {leaderData && (
+                      <MemberCard
+                        memberData={leaderData}
+                        isLeaderUser={isLeaderUser}
+                        mode={'curMembers'}
+                        isLeader={true}
+                      />
+                    )}
+                  </>
+                )}
+                {filteredData?.map((member) => (
+                  <MemberCard
+                    key={member.users.id}
+                    memberData={member}
+                    isLeaderUser={isLeaderUser}
+                    mode={'curMembers'}
+                  />
+                ))}
+              </>
+            )}
+          </div>
         </div>
       </div>
-      <div className="w-1 h-[66px]"></div>
     </div>
   );
 };


### PR DESCRIPTION
## Title

- 모임 멤버 화면 pb 처리

## Changes

- 모임 멤버 화면에서 마지막 멤버가 바텀시트에 가려져 보이지 않았을 때 처리 방식을 pb로 변경했습니다!

## PR 생성 날짜

- 2025.02.05

## CheckList

- [x] 불필요한 주석이 남아 있지는 않은가요?
- [x] 테스트 할 때 사용했던 console.log 가 남아있지 않은가요?
- [x] 코드 컨벤션이 잘 지켜져 있나요?
