### PR TITLE
fix: 이미지 품질 조정

### DIFF
--- a/src/app/groups/[id]/posts/new/_components/PhotoUpload.tsx
+++ b/src/app/groups/[id]/posts/new/_components/PhotoUpload.tsx
@@ -10,7 +10,7 @@ import { DeletePhoto, PlusGray } from '@components/icons';
 import { useState } from 'react';
 
 const MAX_FILES = 10; // 최대 파일 수
-const MAX_WIDTH = 700; // 최대 너비
+const MAX_WIDTH = 1024; // 최대 너비
 const QUALITY = 1; // 이미지 품질 (0 ~ 1)
 
 interface PhotoUploadProps {
@@ -41,7 +41,7 @@ const PhotoUpload = ({ selectedFiles, setSelectedFiles, OpenImageCountAlert }: P
         if (!ctx) return reject('Canvas context not available');
 
         // 이미지 크기 조정
-        const scale = Math.min(MAX_WIDTH / img.width, 1);
+        const scale = img.width > MAX_WIDTH ? Math.min(MAX_WIDTH / img.width, 1) : 1;
         const width = img.width * scale;
         const height = img.height * scale;
 


### PR DESCRIPTION
## Title

- PhotoUpload 로직 이미지 사이즈 조정

## Changes

- PhotoUpload 로직 이미지 해상도가 너무 떨어져 보이는 경우가 있어서 사이즈를 조정해 보았습니다.

## PR 생성 날짜

- 2025.02.07

## CheckList

- [x] 불필요한 주석이 남아 있지는 않은가요?
- [x] 테스트 할 때 사용했던 console.log 가 남아있지 않은가요?
- [ ] 코드 컨벤션이 잘 지켜져 있나요?
