### PR TITLE
fix: 이미지 용량 최적화 작업 완료. 이미지 파일 순서 오름차순 정렬 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ https://github.com/user-attachments/assets/3f91078b-3812-4c40-9d68-244093e007be
 
 # 👨‍👩‍👧‍👦 Team Members
 
-| 박상기                         | 박산하                            | 김민후                         | 박은영                                   | 원윤선                                     |
-| ----------------------------- | -------------------------------- | ----------------------------- | --------------------------------------- | ------------------------------------------ |
-| [@adorable-otter](https://github.com/adorable-otter) | [@heftyCornerstone](https://github.com/heftyCornerstone) | [@minhoo](https://github.com/Kminhoo) | [@euncloud](https://github.com/euncloud) | [@WonYunSun](https://github.com/WonYunSun) |
-| 팀장                             | 부팀장                                         | 팀원                            | 팀원                          | 팀원                              |
-|인증/인가, 일정 캘린더, <br> react native app|홈, 모임 관리, 멤버 목록, <br>모임 가입 신청, 알림|        댓글, 채팅           | 모임방, 게시글CRUD, 사진첩, <br> 공용 컴포넌트, 게시글 검색 |모임 생성, 모임 일정, <br> 공용 컴포넌트  |
+| 박상기                                               | 박산하                                                   | 김민후                                | 박은영                                          | 원윤선                                     |
+| ---------------------------------------------------- | -------------------------------------------------------- | ------------------------------------- | ----------------------------------------------- | ------------------------------------------ |
+| [@adorable-otter](https://github.com/adorable-otter) | [@heftyCornerstone](https://github.com/heftyCornerstone) | [@minhoo](https://github.com/Kminhoo) | [@euncloud](https://github.com/euncloud)        | [@WonYunSun](https://github.com/WonYunSun) |
+| 팀장                                                 | 부팀장                                                   | 팀원                                  | 팀원                                            | 팀원                                       |
+| 인증/인가, 일정 캘린더, <br> react native app        | 홈, 모임 관리, 멤버 목록, <br>모임 가입 신청, 알림       | 댓글, 채팅                            | 모임방(게시글, 사진첩, 검색) <br> 공용 컴포넌트 | 모임 생성, 모임 일정, <br> 공용 컴포넌트   |
 
 <br><br>
 
@@ -56,47 +56,65 @@ https://github.com/user-attachments/assets/3f91078b-3812-4c40-9d68-244093e007be
 
 ### 1. **페이지 구성**
 
-#### 모임 가입 신청  [`/join/[id]`]
+#### 모임 가입 신청 [`/join/[id]`]
+
 - 모임 가입 신청 링크 클릭 시 진입
 
-#### 로그인/회원가입  [`/login`, `/signup`]
+#### 로그인/회원가입 [`/login`, `/signup`]
+
 - 소셜 로그인 기능, 소셜 로그인 간편 회원가입
 
 <br>
 
-#### 홈  [`/`]
+#### 홈 [`/`]
+
 - 가입/대기중 모임 목록
 
-#### 알림  [`/notifiactions`]
+#### 알림 [`/notifiactions`]
+
 - 신규/읽은 알림 확인
 
-#### 마이페이지  [`/mypage`]
+#### 마이페이지 [`/mypage`]
+
 - 프로필 표시, 일정 표시
 
 <br>
 
-#### 채팅  [`/chat`]
+#### 채팅 [`/chat`]
+
 - 채팅방 리스트 업데이트, 채팅 메세지 읽음 처리기능
-  #### 채팅 상세  [`/chat/[id]`]
-    - 채팅 내용 실시간 업데이트, 읽음 처리, AI요약 기능
+  #### 채팅 상세 [`/chat/[id]`]
+  - 채팅 내용 실시간 업데이트, 읽음 처리, AI요약 기능
 
 <br>
 
-#### 모임방  [`/groups/[id]`]
--  모임방 게시글 업데이트
+#### 모임방 [`/groups/[id]`]
 
-    #### 모임 관리  [`/groups/[id]/management`]
-    - 모임 프로필 변경, 모임방 알림 on / off, 모임 탈퇴, 모임 삭제, 모임 초대 링크 복사
+- 모임별 추억 공유 및 관리 기능
 
-    #### 멤버 목록  [`/groups/[id]/management/members`]
-    - 모임 가입 신청 수락 및 거절, 대표 양도
+  #### 게시글 관리 [`/groups/[id]/posts`]
+
+  - 모임 게시글 쓰기, 수정, 삭제, 검색
+
+  #### 일정 관리 [`/groups/[id]/schedules`]
+
+  - 모임 일정 추가, 수정, 삭제, 검색
+
+  #### 모임 관리 [`/groups/[id]/management`]
+
+  - 모임 프로필 변경, 모임방 알림 on / off, 모임 탈퇴, 모임 삭제, 모임 초대 링크 복사
+
+  #### 멤버 목록 [`/groups/[id]/management/members`]
+
+  - 모임 가입 신청 수락 및 거절, 대표 양도
 
 <br>
 
 ### 2. **상세 기능**
 
 #### 모임 가입 신청 페이지
- - 사용자의 다양한 상태에 따른 분기처리
+
+- 사용자의 다양한 상태에 따른 분기처리
 
 #### 사용자 프로필 관리
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-day-picker": "^9.5.0",
     "react-dom": "^18",
     "react-dropzone": "^14.3.5",
+    "react-image-file-resizer": "^0.4.8",
     "react-intersection-observer": "^9.14.1",
     "react-modal-sheet": "^4.0.1",
     "swiper": "^11.2.1",

--- a/src/app/groups/[id]/posts/new/_components/PhotoUpload.tsx
+++ b/src/app/groups/[id]/posts/new/_components/PhotoUpload.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import 'swiper/css';
@@ -7,11 +8,9 @@ import 'swiper/css';
 import Button from '@components/common/Button';
 import { DeletePhoto, PlusGray } from '@components/icons';
 
-import { useState } from 'react';
+import { resizeImage } from '@utils/imageUtils';
 
 const MAX_FILES = 10; // 최대 파일 수
-const MAX_WIDTH = 1024; // 최대 너비
-const QUALITY = 1; // 이미지 품질 (0 ~ 1)
 
 interface PhotoUploadProps {
   selectedFiles: File[];
@@ -21,49 +20,6 @@ interface PhotoUploadProps {
 
 const PhotoUpload = ({ selectedFiles, setSelectedFiles, OpenImageCountAlert }: PhotoUploadProps) => {
   const [previewUrls, setPreviewUrls] = useState<string[]>([]);
-
-  // 이미지 파일 최적화
-  const resizeImage = (file: File): Promise<File> => {
-    return new Promise((resolve, reject) => {
-      const img = new Image();
-      const reader = new FileReader();
-
-      reader.onload = (e) => {
-        img.src = e.target?.result as string;
-      };
-
-      reader.onerror = (e) => reject(e);
-
-      img.onload = () => {
-        const canvas = document.createElement('canvas');
-        const ctx = canvas.getContext('2d');
-
-        if (!ctx) return reject('Canvas context not available');
-
-        // 이미지 크기 조정
-        const scale = img.width > MAX_WIDTH ? Math.min(MAX_WIDTH / img.width, 1) : 1;
-        const width = img.width * scale;
-        const height = img.height * scale;
-
-        canvas.width = width;
-        canvas.height = height;
-
-        ctx.drawImage(img, 0, 0, width, height);
-
-        canvas.toBlob(
-          (blob) => {
-            if (!blob) return reject('Blob conversion failed');
-            const resizedFile = new File([blob], file.name, { type: 'image/jpeg' });
-            resolve(resizedFile);
-          },
-          'image/jpeg',
-          QUALITY
-        );
-      };
-
-      reader.readAsDataURL(file);
-    });
-  };
 
   const { getRootProps, getInputProps } = useDropzone({
     accept: {
@@ -78,12 +34,27 @@ const PhotoUpload = ({ selectedFiles, setSelectedFiles, OpenImageCountAlert }: P
         return;
       }
 
-      // 이미지 리사이즈 처리
-      const resizedFiles = await Promise.all(acceptedFiles.map((file) => resizeImage(file)));
-      const newUrls = resizedFiles.map((file) => URL.createObjectURL(file));
+      try {
+        const resizedResults = await Promise.all(
+          acceptedFiles.map(async (file, index) => {
+            const resizedFile = await resizeImage(file); // 이미지 파일 리사이즈
+            const newUrl = URL.createObjectURL(resizedFile); // 이미지 URL
+            return { index, resizedFile, newUrl };
+          })
+        );
 
-      setSelectedFiles([...selectedFiles, ...resizedFiles]);
-      setPreviewUrls([...previewUrls, ...newUrls]);
+        // 원래 순서대로 정렬
+        const sortedResults = resizedResults.sort((a, b) => a.index - b.index);
+
+        // 파일과 URL을 업데이트
+        const resizedFiles = sortedResults.map((result) => result.resizedFile);
+        const newUrls = sortedResults.map((result) => result.newUrl);
+
+        setSelectedFiles((prevFiles) => [...prevFiles, ...resizedFiles]);
+        setPreviewUrls((prevUrls) => [...prevUrls, ...newUrls]);
+      } catch (error) {
+        console.error('Image resize failed:', error);
+      }
     },
   });
 

--- a/src/queries/photo/getPhotos.ts
+++ b/src/queries/photo/getPhotos.ts
@@ -22,7 +22,25 @@ export const getPhotos = async (groupId: string) => {
       throw new Error(`getPhotos 모임 사진첩 불러오는 중 에러 발생: ${error.message}`);
     }
 
-    return data;
+    // post_images 배열 정렬
+    const formattedData = data.map((post) => ({
+      ...post,
+      post_images: Array.isArray(post.post_images)
+        ? post.post_images.sort((a, b) => {
+            const extractTimestamp = (url: string) => Number(url.split('/').pop()?.split('-')[0]);
+
+            const timeA = extractTimestamp(a.image_url);
+            const timeB = extractTimestamp(b.image_url);
+
+            if (timeA === timeB) {
+              return a.image_url.localeCompare(b.image_url);
+            }
+            return timeA - timeB;
+          })
+        : post.post_images,
+    }));
+
+    return formattedData;
   } catch (err) {
     console.error(err);
     throw new Error(`getPhotos 함수 실행 중 에러 발생: ${(err as Error).message}`);

--- a/src/queries/post/getPosts.ts
+++ b/src/queries/post/getPosts.ts
@@ -57,7 +57,21 @@ export const getPosts = async (
         users: Array.isArray(post.users) ? post.users[0] : post.users,
         schedules: Array.isArray(post.schedules) ? post.schedules[0] : post.schedules,
         comments: Array.isArray(post.comments) ? post.comments[0] : post.comments,
-        post_images: post.post_images,
+        post_images: Array.isArray(post.post_images)
+          ? post.post_images.sort((a, b) => {
+              // 파일명에서 시간 부분 추출 후 비교
+              const extractTimestamp = (url: string) => Number(url.split('/').pop()?.split('-')[0]);
+
+              const timeA = extractTimestamp(a.image_url);
+              const timeB = extractTimestamp(b.image_url);
+
+              // 시간이 같으면 파일명 순으로 비교
+              if (timeA === timeB) {
+                return a.image_url.localeCompare(b.image_url);
+              }
+              return timeA - timeB;
+            })
+          : post.post_images,
       })) || [];
 
     return formattedData;

--- a/src/utils/imageUtils.ts
+++ b/src/utils/imageUtils.ts
@@ -1,0 +1,26 @@
+import Resizer from 'react-image-file-resizer';
+
+const MAX_WIDTH = 900;
+const QUALITY = 90;
+
+// 이미지 리사이즈 함수 (React-Image-File-Resizer 사용)
+export const resizeImage = (file: File): Promise<File> => {
+  return new Promise((resolve, reject) => {
+    Resizer.imageFileResizer(
+      file, // 원본 파일
+      MAX_WIDTH, // 최대 너비
+      MAX_WIDTH, // 최대 높이
+      'webp', // 이미지 포맷
+      QUALITY, // 품질 (0 ~ 100)
+      0, // 회전 각도
+      (resizedFile) => {
+        if (resizedFile instanceof Error) {
+          reject(resizedFile.message);
+        } else {
+          resolve(resizedFile as File);
+        }
+      },
+      'file' // 출력 타입 (file)
+    );
+  });
+};

--- a/src/utils/imageUtils.ts
+++ b/src/utils/imageUtils.ts
@@ -6,6 +6,12 @@ const QUALITY = 90;
 // 이미지 리사이즈 함수 (React-Image-File-Resizer 사용)
 export const resizeImage = (file: File): Promise<File> => {
   return new Promise((resolve, reject) => {
+    // 파일 타입이 이미지가 아닌 경우 예외 처리
+    if (!file.type.startsWith('image/')) {
+      reject(new Error('이미지 파일이 아닙니다.'));
+      return;
+    }
+
     Resizer.imageFileResizer(
       file, // 원본 파일
       MAX_WIDTH, // 최대 너비

--- a/yarn.lock
+++ b/yarn.lock
@@ -3424,6 +3424,11 @@ react-dropzone@^14.3.5:
     file-selector "^2.1.0"
     prop-types "^15.8.1"
 
+react-image-file-resizer@^0.4.8:
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/react-image-file-resizer/-/react-image-file-resizer-0.4.8.tgz#85f4ae4469fd2867d961568af660ef403d7a79af"
+  integrity sha512-Ue7CfKnSlsfJ//SKzxNMz8avDgDSpWQDOnTKOp/GNRFJv4dO9L5YGHNEnj40peWkXXAK2OK0eRIoXhOYpUzUTQ==
+
 react-intersection-observer@^9.14.1:
   version "9.14.1"
   resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-9.14.1.tgz#c9d42576d64dfde18336acdcdf097761fb79ad19"


### PR DESCRIPTION
## Title

- 이미지 용량 최적화 작업 완료. 이미지 파일 순서 오름차순 정렬 추가

## Changes

- 기존에 canvas 를 사용해서 이미지 용량을 최적화 하는 작업을 react-image-file-resizer 라이브러리를 사용하는 방식으로 변경했습니다. 파일을 webp로 압축해서 3~5MB 큰 사진 용량을 90% 이상 줄일 수 있었습니다!
- 해당 내용을 utils > imageUtils.ts 로 분리했습니다.
- 이미지 파일 업로드 순서와 보이는 파일 순서가 일치하지 않는 문제가 있어서 데이터 불러오는 부분에 정렬 코드를 추가했습니다.
- readme 내용 추가했습니다. 저장 할 때 자동으로 빈 줄이 삽입되었어요. 미리보기에는 차이가 없는 것 같은데, 문제가 있으면 말씀해 주세요!

## PR 생성 날짜

- 2025.03.06

## CheckList

- [x] 불필요한 주석이 남아 있지는 않은가요?
- [x] 테스트 할 때 사용했던 console.log 가 남아있지 않은가요?
- [x] 코드 컨벤션이 잘 지켜져 있나요?
